### PR TITLE
Rewrite windows to support multiple output stats

### DIFF
--- a/src/snsary/functions/__init__.py
+++ b/src/snsary/functions/__init__.py
@@ -1,15 +1,17 @@
 """
-A function accepts a single :mod:`Reading <snsary.models.reading>` as an argument and can either return a :mod:`Reading <snsary.models.reading>` or ``None``. This module contains classes whose instances are callable and act as functions.
+A function accepts a single :mod:`Reading <snsary.models.reading>` as an argument and can return zero or more :mod:`Readings <snsary.models.reading>`. This module contains classes whose instances are callable and act as functions.
 """
 
 from .filter import Filter
 from .function import Function
 from .window import Window
 from .window_average import WindowAverage
+from .window_summary import WindowSummary
 
 __all__ = [
     "Filter",
     "Window",
     "WindowAverage",
-    "Function"
+    "Function",
+    "WindowSummary"
 ]

--- a/src/snsary/functions/filter.py
+++ b/src/snsary/functions/filter.py
@@ -6,7 +6,7 @@ class Filter(Function):
         self.__allow_fn = allow_fn
 
     def __call__(self, reading):
-        return reading if self.__allow_fn(reading) else None
+        return [reading] if self.__allow_fn(reading) else []
 
     @property
     def invert(self):

--- a/src/snsary/functions/window.py
+++ b/src/snsary/functions/window.py
@@ -1,14 +1,20 @@
 """
-Base class for functions that aggregate :mod:`Readings <snsary.models.reading>` over a fixed, consecutive periods. A subclass should define an ``_aggregate`` method that is called each time the age of the window for a sensor / reading name pair reaches the specified period. The windows are consecutive, not moving: after a window has been aggregated a new window is created with the last :mod:`Reading <snsary.models.reading>`.
+Base class for functions that aggregate :mod:`Readings <snsary.models.reading>` over fixed, consecutive periods, specified as the keyword arguments for a ``timedelta`` (seconds, minutes, etc.).
+
+A subclass should define an ``_aggregate`` method that is called each time the age of the window for a sensor / reading name pair reaches the specified period.
+
+The windows are consecutive, not moving: after a window has been aggregated a new window is started using the :mod:`Reading <snsary.models.reading>` that triggered the previous window to close.
 """
 
+
+from datetime import timedelta
 
 from .function import Function
 
 
 class Window(Function):
-    def __init__(self, *, period=10):
-        self.__period = period
+    def __init__(self, **kwargs):
+        self.__period = timedelta(**kwargs).total_seconds()
         self.__windows = dict()
 
     def __call__(self, reading):
@@ -17,7 +23,7 @@ class Window(Function):
         if not self.__windows.get(key, []):
             self.logger.debug(f"Starting window for {key}.")
             self.__windows[key] = [reading]
-            return
+            return []
 
         readings = self.__windows[key]
         start = readings[0].timestamp
@@ -30,6 +36,7 @@ class Window(Function):
 
         readings += [reading]
         self.__windows[key] = readings
+        return []
 
     def aggregate(readings):
         raise NotImplementedError()

--- a/src/snsary/functions/window_average.py
+++ b/src/snsary/functions/window_average.py
@@ -11,9 +11,9 @@ from .window import Window
 
 class WindowAverage(Window):
     def _aggregate(self, readings):
-        return Reading(
+        return [Reading(
             sensor=readings[0].sensor,
             name=readings[0].name,
             timestamp_seconds=readings[-1].timestamp,
             value=mean(r.value for r in readings)
-        )
+        )]

--- a/src/snsary/functions/window_summary.py
+++ b/src/snsary/functions/window_summary.py
@@ -1,0 +1,31 @@
+"""
+Computes the mean, max, min and median (p50) of :mod:`Readings <snsary.models.reading>` over consecutive windows. The name of each computation is appended to the name of the :mod:`Reading <snsary.models.reading>` e.g. ``myreading--mean``.
+"""
+
+from statistics import mean, median
+
+from snsary.models import Reading
+
+from .window import Window
+
+
+class WindowSummary(Window):
+    def _aggregate(self, readings):
+        def __dup_reading(name, value):
+            source = readings[-1]
+
+            return Reading(
+                sensor=source.sensor,
+                name=source.name + f'--{name}',
+                timestamp_seconds=source.timestamp,
+                value=value
+            )
+
+        values = [r.value for r in readings]
+
+        return [
+            __dup_reading('mean', mean(values)),
+            __dup_reading('max', max(values)),
+            __dup_reading('min', min(values)),
+            __dup_reading('p50', median(values))
+        ]

--- a/src/snsary/streams/__init__.py
+++ b/src/snsary/streams/__init__.py
@@ -1,24 +1,26 @@
 """
-A :mod:`Stream <snsary.streams.stream>` is an :mod:`Output <snsary.outputs.output>` and a :mod:`Source <snsary.sources.source>`. Being an :mod:`Output <snsary.outputs.output>` means :mod:`Sources <snsary.sources.source>` can feed into it. Being a :mod:`Source <snsary.sources.source>` means it can feed :mod:`Outputs <snsary.outputs.output>`. All :mod:`Sensors <snsary.sources.sensor>` expose a ``stream`` of their :mod:`Readings <snsary.models.reading>` e.g. ``MockSensor().stream`` returns an :mod:`AsyncStream <snsary.streams.async_stream>`.
+A :mod:`Stream <snsary.streams.stream>` is an :mod:`Output <snsary.outputs.output>` and a :mod:`Source <snsary.sources.source>` that provides some kind of additional functionality over connecting :mod:`Sources <snsary.sources.source>` to :mod:`Outputs <snsary.outputs.output>` directly. All :mod:`Sensors <snsary.sources.sensor>` expose a ``stream`` of their :mod:`Readings <snsary.models.reading>` e.g. ``MockSensor().stream`` returns an :mod:`AsyncStream <snsary.streams.async_stream>` to cope with flakey :mod:`Outputs <snsary.outputs.output>`.
 
-Any Stream can be wrapped in a filter e.g. ::
-
-    stream.filter(lambda r: True).subscribe(MockOutput())
-
-    stream.filter_names('a', 'b', 'c').subscribe(MockOutput())
-
-To help make filter functions there is a :mod:`Filter <snsary.functions.filter>` class. Streams also make it easy to subscribe multiple :mod:`Outputs <snsary.outputs.output>` by passing them all to ``.into()``: ::
+Streams make it easy to subscribe multiple :mod:`Outputs <snsary.outputs.output>` with ``into``: ::
 
     # same as calling "subscribe" for each
     stream.into(MockOutput(), MockOutput())
 
-A stream can actually be used to ``apply`` any :mod:`function <snsary.functions>` to the readings that pass through it. For example, to average the distinct readings received in a window: ::
+Any :mod:`Stream <snsary.streams.stream>` can also be wrapped in a :mod:`Filter <snsary.functions.filter>` function e.g. ::
 
-    # output an average every 3 readings
-    # for each distinct sensor / reading name
-    stream.average(size=3).into(MockOutput())
+    # only output readings for sensor "foo"
+    stream.apply(Filter.sensor_name('foo')).into(MockOutput())
 
-``average`` is just a convenience method for ``apply``.
+    # only output readings called "a", etc.
+    # convenience shortcut method for "apply"
+    stream.filter_names('a', 'b', 'c').subscribe(MockOutput())
+
+A stream can actually be used to ``apply`` any one-to-many :mod:`function <snsary.functions>` to the readings that pass through it. For example, to average the distinct readings received in a window: ::
+
+    # outputs an average value every 3 seconds
+    # for each distinct sensor / reading name;
+    # convenience shortcut method for "apply"
+    stream.average(seconds=3).into(MockOutput())
 """
 
 

--- a/src/snsary/streams/func_stream.py
+++ b/src/snsary/streams/func_stream.py
@@ -1,5 +1,5 @@
 """
-Only publishes a :mod:`Reading <snsary.models.Reading>` if the specified :mod:`function <snsary.functions>` returns a :mod:`Reading <snsary.models.Reading>` for it. This could be the same reading or a different one. Nothing is published if the :mod:`function <snsary.functions>` returns ``None``.
+Publishes zero or more :mod:`Readings <snsary.models.Reading>` depending on what the specified :mod:`function <snsary.functions>` returns for a given :mod:`Reading <snsary.models.reading>`. This could be nothing, the same reading, or multiple, different readings.
 """
 from .simple_stream import SimpleStream
 
@@ -8,14 +8,14 @@ class FuncStream(SimpleStream):
     def __init__(
         self,
         stream,
-        function=lambda reading: reading
+        function=lambda reading: [reading]
     ):
         SimpleStream.__init__(self)
         stream.subscribe(self)
         self.__function = function
 
     def publish(self, reading):
-        output_reading = self.__function(reading)
+        output_readings = self.__function(reading)
 
-        if output_reading:
+        for output_reading in output_readings:
             SimpleStream.publish(self, output_reading)

--- a/src/snsary/streams/stream.py
+++ b/src/snsary/streams/stream.py
@@ -1,4 +1,4 @@
-from snsary.functions import Filter, WindowAverage
+from snsary.functions import Filter, WindowAverage, WindowSummary
 from snsary.outputs import Output
 from snsary.sources import Source
 
@@ -12,15 +12,17 @@ class Stream(Source, Output):
         from .func_stream import FuncStream
         return FuncStream(self, function)
 
-    def filter(self, filter):
-        def _filter(reading):
-            if filter(reading):
-                return reading
-
-        return self.apply(_filter)
-
     def filter_names(self, *names):
         return self.apply(Filter.names(*names))
 
-    def average(self, period=10):
-        return self.apply(WindowAverage(period=period))
+    def average(self, **kwargs):
+        """
+        Returns a new stream that applies a :mod:`WindowAverage <snsary.functions.window_average>` to all :mod:`Readings <snsary.models.reading>` over a period, specified as the keyword arguments for a ``timedelta``.
+        """
+        return self.apply(WindowAverage(**kwargs))
+
+    def summarize(self, **kwargs):
+        """
+        Returns a new stream that applies a :mod:`WindowSummary <snsary.functions.window_summary>` to all :mod:`Readings <snsary.models.reading>` over a period, specified as the keyword arguments for a ``timedelta``.
+        """
+        return self.apply(WindowSummary(**kwargs))

--- a/tests/functions/test_window_average.py
+++ b/tests/functions/test_window_average.py
@@ -3,12 +3,13 @@ from tests.conftest import create_reading
 
 
 def test_window_average():
-    window = WindowAverage(period=2)
+    window = WindowAverage(seconds=2)
 
     assert not window(create_reading(value=1, timestamp_seconds=1))
     assert not window(create_reading(value=2, timestamp_seconds=2))
 
-    reading = window(create_reading(value=3, timestamp_seconds=3))
-    assert reading.value == 1.5
+    readings = window(create_reading(value=3, timestamp_seconds=3))
+    assert len(readings) == 1
+    assert readings[0].value == 1.5
 
     assert not window(create_reading(timestamp_seconds=4))

--- a/tests/functions/test_window_summary.py
+++ b/tests/functions/test_window_summary.py
@@ -1,0 +1,23 @@
+from snsary.functions import WindowSummary
+from tests.conftest import create_reading
+
+
+def test_window_summary():
+    window = WindowSummary(seconds=2)
+
+    assert not window(create_reading(value=1, timestamp_seconds=1))
+    assert not window(create_reading(value=2, timestamp_seconds=2))
+
+    readings = window(create_reading(value=3, timestamp_seconds=3))
+
+    assert len(readings) == 4
+    assert readings[0].name == 'myreading--mean'
+    assert readings[0].value == 1.5
+    assert readings[1].name == 'myreading--max'
+    assert readings[1].value == 2
+    assert readings[2].name == 'myreading--min'
+    assert readings[2].value == 1
+    assert readings[3].name == 'myreading--p50'
+    assert readings[3].value == 1.5
+
+    assert not window(create_reading(timestamp_seconds=4))

--- a/tests/streams/test_stream.py
+++ b/tests/streams/test_stream.py
@@ -24,25 +24,13 @@ def output():
 
 def test_apply(stream, output):
     def _function(reading):
-        return create_reading(value=2)
+        return [create_reading(value=2)]
 
     stream.apply(_function).into(output)
     stream.publish(create_reading(value=1))
 
     assert len(output.readings) == 1
     assert output.readings[0].value == 2
-
-
-def test_filter(stream, output):
-    stream.filter(
-        lambda reading: reading.name == 'pass'
-    ).into(output)
-
-    stream.publish(create_reading(name='fail'))
-    stream.publish(create_reading(name='pass'))
-
-    assert len(output.readings) == 1
-    assert output.readings[0].name == 'pass'
 
 
 def test_filter_names(stream, output):
@@ -55,7 +43,7 @@ def test_filter_names(stream, output):
 
 
 def test_average(stream, output):
-    stream.average(period=2).into(output)
+    stream.average(seconds=2).into(output)
 
     for i in range(3):
         stream.publish(create_reading(
@@ -63,4 +51,17 @@ def test_average(stream, output):
         ))
 
     assert len(output.readings) == 1
+    assert output.readings[0].value == 1.5
+
+
+def test_summarize(stream, output):
+    stream.summarize(seconds=2).into(output)
+
+    for i in range(3):
+        stream.publish(create_reading(
+            value=i+1, timestamp_seconds=i
+        ))
+
+    assert len(output.readings) == 4
+    assert output.readings[0].name == 'myreading--mean'
     assert output.readings[0].value == 1.5


### PR DESCRIPTION
https://trello.com/c/6sVpeSmv/4-sort-out-long-term-storage

This supports more advanced aggregations with multiple values, such
as the new WindowSummary function. Although this could be achieved
with individual functions and multiple chains in the calling code,
it's simpler to compute them all in one place.

Given that windows may be applied over long periods, it makes sense
to allow multiple units for the period argument.

The richer behaviour of Windows isn't ideal for Filter, which could
potentially be simplified in future with a suitable parent class to
abstract the array output. Given the additional complexity, this was
a good opportunity to remove the unused Stream.filter.