### PR TITLE
Add persistent auto-IAQ calibration for SGP30

### DIFF
--- a/docs/examples/contrib.py
+++ b/docs/examples/contrib.py
@@ -32,7 +32,6 @@ longterm_stream.summarize(hours=1).rename(append="/hour").into(graphql)
 longterm_stream.summarize(days=1).rename(append="/day").into(graphql)
 
 sgp30 = SGP30Sensor(Adafruit_SGP30(i2c))
-sgp30.device.set_iaq_baseline(TVOC=37036, eCO2=35816)
 
 MultiSource(
     *AwairSensor.discover_from_env(),

--- a/docs/extras/i2c.md
+++ b/docs/extras/i2c.md
@@ -91,10 +91,7 @@ Temperature / humidity can't be adjusted easily: the calibration values are docu
 - [Datasheet](https://cdn-learn.adafruit.com/assets/assets/000/050/058/original/Sensirion_Gas_Sensors_SGP30_Datasheet_EN.pdf)
 - [Shop link](https://thepihut.com/products/adafruit-sgp30-air-quality-sensor-breakout-voc-and-eco2-ada3709)
 
-TODO:
-
-- evaluation
-- calibration
+This needs some calibration ([see API docs](https://snsary.readthedocs.io/en/latest/autoapi/snsary/contrib/adafruit/index.html)) but ultimately produces comparable TVOC trends and even values compared to another, benchmark VOC sensor. As with the benchmark sensor, most of the trends can be attributed to household activities. There's a fairly constant or "background" TVOC level of 100-200 unless a window is open; this makes it hard to use the sensor as a meaningful indicator of pollution in an indoor environment.
 
 ### Pimoroni
 

--- a/src/snsary/utils/tracker.py
+++ b/src/snsary/utils/tracker.py
@@ -1,0 +1,80 @@
+"""
+Utility to track the values of readings with specified names using persistent :mod:`storage <snsary.utils.storage>`. New values are individually compared with old using a specified function e.g. ::
+
+    Tracker('id-for-persistent-storage', myreading=max, othername=min)
+
+Call ``update`` when new readings are available. ``on_change`` is called when one or more tracked values change - set to a different function to subscribe to changes.
+"""
+
+from .logger import HasLogger
+from .storage import HasStore
+
+
+class Tracker(HasLogger, HasStore):
+    def __init__(self, id, **trackers):
+        self.__trackers = trackers
+        self.__id = id
+
+    @property
+    def values(self):
+        return self.store.get(f'{self.__id}-tracked-values', {})
+
+    def on_change(self, old, new):
+        pass
+
+    def update(self, readings):
+        values = self.values
+        new_values = {}
+
+        for name, fn in self.__trackers.items():
+            current_value = self.__filter_value(readings, name)
+
+            if not current_value:
+                self.logger.debug(f'Missing value for {name}.')
+                return
+
+            if name not in values:
+                self.logger.debug(f'Filling empty value for {name}.')
+                new_values[name] = current_value
+            else:
+                new_values[name] = fn(current_value, values[name])
+
+        if new_values == values:
+            self.logger.debug('Tracked values unchanged.')
+            return
+
+        self.logger.debug(f'Storing tracked values: {new_values}')
+        self.store[f'{self.__id}-tracked-values'] = new_values
+        self.on_change(values, new_values)
+
+    def __filter_value(self, readings, name):
+        for reading in readings:
+            if reading.name == name:
+                return reading.value
+
+
+class MaxTracker(Tracker):
+    def __init__(self, id, *, names, on_change):
+        self.on_change = on_change
+
+        Tracker.__init__(
+            self, id, **{name: max for name in names}
+        )
+
+
+class NullTracker(Tracker):
+    def __init__(self):
+        pass
+
+    def update(self, readings):
+        """
+        Does nothing.
+        """
+        return
+
+    @property
+    def values(self):
+        """
+        Returns {}.
+        """
+        return {}

--- a/tests/contrib/adafruit/test_sgp30.py
+++ b/tests/contrib/adafruit/test_sgp30.py
@@ -1,6 +1,7 @@
 import pytest
 
 from snsary.contrib.adafruit.sgp30 import SGP30Sensor
+from snsary.utils.tracker import MaxTracker, NullTracker
 from tests.conftest import create_reading
 
 
@@ -14,8 +15,51 @@ def mock_sgp30(mocker):
 
 
 @pytest.fixture
+def mock_generic(mocker):
+    return mocker.patch(
+        'snsary.contrib.adafruit.sgp30.GenericSensor',
+    )
+
+
+@pytest.fixture
 def sensor(mock_sgp30):
     return SGP30Sensor(mock_sgp30)
+
+
+def test_init(sensor):
+    assert isinstance(sensor.tracker, MaxTracker)
+
+
+def test_init_no_persist(mock_sgp30):
+    sensor = SGP30Sensor(mock_sgp30, persistent_baselines=False)
+    assert isinstance(sensor.tracker, NullTracker)
+
+
+def test_start(
+    sensor,
+    mock_generic,
+    mock_sgp30,
+):
+    sensor.start()
+    mock_generic.start.assert_called()
+    mock_sgp30.set_iaq_baseline.assert_not_called()
+
+
+def test_start_restore(
+    sensor,
+    mock_sgp30,
+    mock_generic,
+    mock_store
+):
+    mock_store['SGP30-tracked-values'] = {
+        'baseline_TVOC': 123, 'baseline_eCO2': 456
+    }
+
+    sensor.start()
+
+    mock_sgp30.set_iaq_baseline.assert_called_with(
+        TVOC=123, eCO2=456
+    )
 
 
 def test_ready(sensor):
@@ -42,3 +86,21 @@ def test_publish_batch(sensor, mock_sgp30):
 def test_publish_batch_incomplete(sensor, mock_sgp30, readings):
     sensor.publish_batch(readings)
     mock_sgp30.set_iaq_humidity.assert_not_called()
+
+
+def test_sample(sensor, mock_generic, mocker):
+    mock_generic.sample.return_value = ['readings']
+    mock_tracker = mocker.patch.object(sensor, 'tracker')
+
+    assert sensor.sample() == ['readings']
+    mock_tracker.update.assert_called_with(['readings'])
+
+
+def test_tracked_values_changed(sensor, mock_sgp30):
+    sensor.tracker.on_change(
+        None, {'baseline_TVOC': 'tvoc', 'baseline_eCO2': 'eco2'}
+    )
+
+    mock_sgp30.set_iaq_baseline.assert_called_with(
+        TVOC='tvoc', eCO2='eco2'
+    )

--- a/tests/utils/test_tracker.py
+++ b/tests/utils/test_tracker.py
@@ -1,0 +1,66 @@
+import pytest
+
+from snsary.utils.tracker import Tracker
+from tests.conftest import create_reading
+
+
+@pytest.fixture
+def tracker():
+    class FakeTracker(Tracker):
+        def __init__(self):
+            Tracker.__init__(self, 'FakeTracker', foo=max, bar=min)
+
+        def on_change(self, old, new):
+            self.changed_old = old
+            self.changed_new = new
+
+    return FakeTracker()
+
+
+def test_update(tracker, mock_store):
+    readings = [
+        create_reading(name='foo', value=1),
+        create_reading(name='bar', value=2),
+        create_reading(name='other')
+    ]
+
+    old_values = {'foo': 0, 'bar': 1}
+    mock_store['FakeTracker-tracked-values'] = old_values
+
+    tracker.update(readings)
+    assert tracker.changed_old == old_values
+
+    expected_values = {'foo': 1, 'bar': 1}
+    assert mock_store['FakeTracker-tracked-values'] == expected_values
+    assert tracker.changed_new == expected_values
+
+
+def test_update_no_store(tracker, mock_store):
+    readings = [
+        create_reading(name='foo', value=1),
+        create_reading(name='bar', value=2),
+    ]
+
+    tracker.update(readings)
+    assert tracker.changed_old == {}
+
+    expected_values = {'foo': 1, 'bar': 2}
+    assert mock_store['FakeTracker-tracked-values'] == expected_values
+    assert tracker.changed_new == expected_values
+
+
+@pytest.mark.parametrize('readings', [
+    [create_reading(name='foo')],
+    [create_reading(name='foo', value=1), create_reading(name='bar', value=2)],
+])
+def test_update_no_change(
+    tracker,
+    mock_store,
+    readings
+):
+    expected_values = {'foo': 1, 'bar': 2}
+    mock_store['FakeTracker-tracked-values'] = expected_values
+
+    tracker.update(readings)
+    assert 'changed_new' not in dir(tracker)
+    assert mock_store['FakeTracker-tracked-values'] == expected_values


### PR DESCRIPTION
https://trello.com/c/sdLMn4o2/1-investigate-gas-sensor

This abstracts the persistent calibration into a new Tracker utility,
although hopefully most other sensors will offer onboard persistence.

Using the all-time maximum values of the baseline readings avoids the
sensor adjusting to days with more or less fresh air. From memory the
initial baseline values were much lower than those after calibration,
so it should be OK to start tracking them immediately.