### PR TITLE
Protect serial code from parallel execution

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,1 +1,2 @@
 cachetools
+wrapt

--- a/src/snsary/outputs/__init__.py
+++ b/src/snsary/outputs/__init__.py
@@ -1,3 +1,7 @@
+"""
+An Output has a ``publish`` method to receive :mod:`Readings <snsary.models.reading>`. Note that ``publish`` may be called concurrently if an Output is attached to multiple asynchronous :mod:`Sources <snsary.sources.source>`.
+"""
+
 from .batch_output import BatchOutput
 from .mock_output import MockOutput
 from .output import Output

--- a/src/snsary/outputs/batch_output.py
+++ b/src/snsary/outputs/batch_output.py
@@ -1,8 +1,12 @@
 """
-Depending on the output, it may be more efficient to dispatch multiple :mod:`Readings<snsary.models.reading>` together. This can be done by inheriting from BatchOutput, which requires a ``publish_batch`` method. BatchOutput is also a :mod:`Service <snsary.utils.service>` and will try to publish any remaining Readings when told to ``stop()``.
+Depending on the output, it may be more efficient to dispatch multiple :mod:`Readings<snsary.models.reading>` together. This can be done by inheriting from BatchOutput, which requires a ``publish_batch`` method.
+
+BatchOutput protects against concurrent execution of its ``publish`` method. BatchOutput is also a :mod:`Service <snsary.utils.service>` and will try to publish any remaining Readings when told to ``stop()``.
 """
 
 from datetime import datetime
+
+from wrapt import synchronized
 
 from snsary.utils import Service
 
@@ -30,6 +34,7 @@ class BatchOutput(Output, Service):
         if self.__readings:
             self.flush()
 
+    @synchronized
     def publish(self, reading):
         self.__readings += [reading]
         self.__try_publish_large_batch()

--- a/src/snsary/streams/func_stream.py
+++ b/src/snsary/streams/func_stream.py
@@ -1,6 +1,8 @@
 """
 Publishes zero or more :mod:`Readings <snsary.models.Reading>` depending on what the specified :mod:`function <snsary.functions>` returns for a given :mod:`Reading <snsary.models.reading>`. This could be nothing, the same reading, or multiple, different readings.
 """
+from wrapt import synchronized
+
 from .simple_stream import SimpleStream
 
 
@@ -14,6 +16,7 @@ class FuncStream(SimpleStream):
         stream.subscribe(self)
         self.__function = function
 
+    @synchronized
     def publish(self, reading):
         output_readings = self.__function(reading)
 


### PR DESCRIPTION
https://trello.com/c/8covwHVK/7-cope-with-transient-failures

BatchOutput and Functions both require synchronisation as they do
non-thread-safe computations e.g. modifying arrays.

In general an Output may benefit from accepting multiple Readings
in parallel. All contrib/ Outputs inherit from BatchOutput though.
Some Outputs may benefit from the synchronisation - GraphQLOutput
has been emitting "Transport is already connected" errors.