### PR TITLE
Add black linter to standardise formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ bootstrap-all: bootstrap
 	cat requirements/*/tests.txt | xargs pip install
 
 test:
+	black --check .
 	isort --check-only .
 	flake8 .
 	pytest --ignore=tests/contrib

--- a/docs/examples/button.py
+++ b/docs/examples/button.py
@@ -29,12 +29,14 @@ class ButtonSensor(PollingSensor):
         self.__button.direction = digitalio.Direction.INPUT
 
     def sample(self, timestamp, **kwargs):
-        return [Reading(
-            sensor_name=self.name,
-            name='pressed',
-            timestamp=timestamp,
-            value=self.__button.value
-        )]
+        return [
+            Reading(
+                sensor_name=self.name,
+                name="pressed",
+                timestamp=timestamp,
+                value=self.__button.value,
+            )
+        ]
 
 
 ButtonSensor().subscribe(MockOutput())

--- a/docs/examples/contrib.py
+++ b/docs/examples/contrib.py
@@ -39,7 +39,7 @@ sgp30 = SGP30Sensor(Adafruit_SGP30(i2c))
 
 MultiSource(
     *AwairSensor.discover_from_env(),
-    PyPMSSensor(sensor_name='PMSx003'),
+    PyPMSSensor(sensor_name="PMSx003"),
     AdafruitSensor(SCD30(i2c)).stream.tee(sgp30),
     AdafruitSensor(BH1750(i2c)),
     AdafruitSensor(MS8607(i2c)),

--- a/docs/examples/ssd1306.py
+++ b/docs/examples/ssd1306.py
@@ -38,7 +38,7 @@ class OLEDOutput(Output, Service):
     def publish(self, reading):
         self.__count += 1
         self.__display.fill(0)
-        self.__display.text(f'Sent {self.__count} readings.', 0, 0, color=1)
+        self.__display.text(f"Sent {self.__count} readings.", 0, 0, color=1)
         self.__display.show()
 
 

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -17,9 +17,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'Snsary'
-copyright = '2022, Ben Thorner'
-author = 'Ben Thorner'
+project = "Snsary"
+copyright = "2022, Ben Thorner"
+author = "Ben Thorner"
 
 
 # -- General configuration ---------------------------------------------------
@@ -27,27 +27,20 @@ author = 'Ben Thorner'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    'autoapi.extension'
-]
+extensions = ["autoapi.extension"]
 
-autoapi_type = 'python'
-autoapi_dirs = ['../../src']
+autoapi_type = "python"
+autoapi_dirs = ["../../src"]
 autoapi_add_toctree_entry = False
-autoapi_options = [
-    'members',
-    'undoc-members',
-    'special-members',
-    'show-inheritance'
-]
+autoapi_options = ["members", "undoc-members", "special-members", "show-inheritance"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -55,7 +48,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -27,12 +27,19 @@ author = "Ben Thorner"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["autoapi.extension"]
+extensions = [
+    "autoapi.extension",
+]
 
 autoapi_type = "python"
 autoapi_dirs = ["../../src"]
 autoapi_add_toctree_entry = False
-autoapi_options = ["members", "undoc-members", "special-members", "show-inheritance"]
+autoapi_options = [
+    "members",
+    "undoc-members",
+    "special-members",
+    "show-inheritance",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -8,3 +8,4 @@ time-machine
 sphinx-autoapi
 sphinx-rtd-theme
 sphinx-autobuild
+black

--- a/setup.py
+++ b/setup.py
@@ -21,16 +21,17 @@ setuptools.setup(
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.8",
     install_requires=[
-        *open('requirements/default.txt').read().splitlines(),
+        *open("requirements/default.txt").read().splitlines(),
     ],
     extras_require={
         **{
             path.parent.stem: open(path).read().splitlines()
-            for path in Path('requirements/').glob('*/extra.txt')
+            for path in Path("requirements/").glob("*/extra.txt")
         },
-        'all': set(
-            line for path in Path('requirements/').glob('*/extra.txt')
+        "all": set(
+            line
+            for path in Path("requirements/").glob("*/extra.txt")
             for line in open(path).read().splitlines()
-        )
-    }
+        ),
+    },
 )

--- a/src/snsary/contrib/adafruit/__init__.py
+++ b/src/snsary/contrib/adafruit/__init__.py
@@ -1,3 +1,5 @@
 from .generic import GenericSensor
 
-__all__ = ["GenericSensor"]
+__all__ = [
+    "GenericSensor",
+]

--- a/src/snsary/contrib/adafruit/__init__.py
+++ b/src/snsary/contrib/adafruit/__init__.py
@@ -1,5 +1,3 @@
 from .generic import GenericSensor
 
-__all__ = [
-    "GenericSensor"
-]
+__all__ = ["GenericSensor"]

--- a/src/snsary/contrib/adafruit/generic.py
+++ b/src/snsary/contrib/adafruit/generic.py
@@ -62,7 +62,7 @@ class GenericSensor(PollingSensor):
                 sensor_name=self.name,
                 name=name,
                 value=value,
-                timestamp=kwargs['timestamp']
+                timestamp=kwargs["timestamp"],
             )
             for (name, value) in self.__scraper(self.device)
         ]

--- a/src/snsary/contrib/adafruit/sgp30.py
+++ b/src/snsary/contrib/adafruit/sgp30.py
@@ -56,7 +56,7 @@ class SGP30Sensor(GenericSensor, BatchOutput):
             self.tracker = MaxTracker(
                 self.name,
                 names=["baseline_TVOC", "baseline_eCO2"],
-                on_change=self.tracked_values_changed,
+                on_change=self.baselines_changed,
             )
         else:
             self.tracker = NullTracker()
@@ -68,7 +68,7 @@ class SGP30Sensor(GenericSensor, BatchOutput):
 
     def start(self):
         if self.tracker.values:
-            self.tracked_values_changed({}, self.tracker.values)
+            self.baselines_changed(old={}, new=self.tracker.values)
         else:
             self.logger.debug("No baselines to restore, using defaults.")
 
@@ -82,11 +82,11 @@ class SGP30Sensor(GenericSensor, BatchOutput):
         self.tracker.update(readings)
         return readings
 
-    def tracked_values_changed(self, _, baselines):
-        self.logger.debug(f"Setting baselines: {baselines}")
+    def baselines_changed(self, old, new):
+        self.logger.debug(f"Setting baselines: {new}")
 
         self.device.set_iaq_baseline(
-            eCO2=baselines["baseline_eCO2"], TVOC=baselines["baseline_TVOC"]
+            eCO2=new["baseline_eCO2"], TVOC=new["baseline_TVOC"]
         )
 
     def publish_batch(self, readings):

--- a/src/snsary/contrib/adafruit/sgp30.py
+++ b/src/snsary/contrib/adafruit/sgp30.py
@@ -55,22 +55,22 @@ class SGP30Sensor(GenericSensor, BatchOutput):
         if persistent_baselines:
             self.tracker = MaxTracker(
                 self.name,
-                names=['baseline_TVOC', 'baseline_eCO2'],
-                on_change=self.tracked_values_changed
+                names=["baseline_TVOC", "baseline_eCO2"],
+                on_change=self.tracked_values_changed,
             )
         else:
             self.tracker = NullTracker()
-            self.logger.debug('Persistent baselines disabled, ignoring.')
+            self.logger.debug("Persistent baselines disabled, ignoring.")
 
     @property
     def name(self):
-        return 'SGP30'
+        return "SGP30"
 
     def start(self):
         if self.tracker.values:
             self.tracked_values_changed({}, self.tracker.values)
         else:
-            self.logger.debug('No baselines to restore, using defaults.')
+            self.logger.debug("No baselines to restore, using defaults.")
 
         GenericSensor.start(self)
 
@@ -83,23 +83,23 @@ class SGP30Sensor(GenericSensor, BatchOutput):
         return readings
 
     def tracked_values_changed(self, _, baselines):
-        self.logger.debug(f'Setting baselines: {baselines}')
+        self.logger.debug(f"Setting baselines: {baselines}")
 
         self.device.set_iaq_baseline(
-            eCO2=baselines['baseline_eCO2'], TVOC=baselines['baseline_TVOC']
+            eCO2=baselines["baseline_eCO2"], TVOC=baselines["baseline_TVOC"]
         )
 
     def publish_batch(self, readings):
-        temperatures = self.__filter(readings, 'temperature')
-        relative_humidities = self.__filter(readings, 'relative_humidity')
+        temperatures = self.__filter(readings, "temperature")
+        relative_humidities = self.__filter(readings, "relative_humidity")
 
         if not temperatures or not relative_humidities:
-            self.logger.warning('Incomplete data for self-calibration.')
+            self.logger.warning("Incomplete data for self-calibration.")
             return
 
         self.device.set_iaq_relative_humidity(
             celsius=temperatures[-1].value,
-            relative_humidity=relative_humidities[-1].value
+            relative_humidity=relative_humidities[-1].value,
         )
 
     def __filter(self, readings, name):

--- a/src/snsary/contrib/awair.py
+++ b/src/snsary/contrib/awair.py
@@ -81,19 +81,18 @@ class AwairSensor(PollingSensor):
         samples = response.json()["data"]
         self.logger.debug("Response {samples}")
 
-        return [
-            reading for sample in samples for reading in self.__sample_readings(sample)
-        ]
+        for sample in samples:
+            yield from self.__readings_from_sample(sample)
 
-    def __sample_readings(self, sample):
+    def __readings_from_sample(self, sample):
         sample_timestamp = int(pyrfc3339.parse(sample["timestamp"]).timestamp())
 
-        return (
-            Reading(
-                sensor_name=self.name,
-                name=sensor["comp"],
-                timestamp=sample_timestamp,
-                value=sensor["value"],
+        for sensor in sample["sensors"]:
+            yield (
+                Reading(
+                    sensor_name=self.name,
+                    name=sensor["comp"],
+                    timestamp=sample_timestamp,
+                    value=sensor["value"],
+                )
             )
-            for sensor in sample["sensors"]
-        )

--- a/src/snsary/contrib/awair.py
+++ b/src/snsary/contrib/awair.py
@@ -24,27 +24,25 @@ class AwairSensor(PollingSensor):
 
     @classmethod
     def discover_from_env(cls):
-        return cls.discover(
-            token=os.environ['AWAIR_TOKEN']
-        )
+        return cls.discover(token=os.environ["AWAIR_TOKEN"])
 
     @classmethod
     def discover(cls, *, token):
-        get_logger().debug(f'Request {cls.DEVICES_URL}')
+        get_logger().debug(f"Request {cls.DEVICES_URL}")
         response = requests.get(
-            cls.DEVICES_URL, headers={'Authorization': f'Bearer {token}'}
+            cls.DEVICES_URL, headers={"Authorization": f"Bearer {token}"}
         )
         response.raise_for_status()
         devices = response.json()["devices"]
 
         get_logger().info(f"Discovered {len(devices)} Awair devices.")
-        get_logger().debug(f'Discovered {devices}')
+        get_logger().debug(f"Discovered {devices}")
 
         return [
             AwairSensor(
-                device_type=device['deviceType'],
-                device_id=device['deviceId'],
-                token=token
+                device_type=device["deviceType"],
+                device_id=device["deviceId"],
+                token=token,
             )
             for device in devices
         ]
@@ -57,43 +55,41 @@ class AwairSensor(PollingSensor):
 
     @property
     def name(self):
-        return f'{self.__device_type}-{self.__device_id}'
+        return f"{self.__device_type}-{self.__device_id}"
 
     def sample(self, now, **kwargs):
         # subtract double period in case of delayed readings
         sample_start = now - timedelta(seconds=self.PERIOD * 2)
 
-        url = self.DATA_URL.format(**{
-            'deviceType': self.__device_type,
-            'deviceId': self.__device_id,
-            'from': pyrfc3339.generate(sample_start)
-        })
+        url = self.DATA_URL.format(
+            **{
+                "deviceType": self.__device_type,
+                "deviceId": self.__device_id,
+                "from": pyrfc3339.generate(sample_start),
+            }
+        )
 
-        self.logger.debug(f'Request {url}')
+        self.logger.debug(f"Request {url}")
         response = requests.get(
-            url,
-            headers={'Authorization': f'Bearer {self.__token}'}
+            url, headers={"Authorization": f"Bearer {self.__token}"}
         )
         response.raise_for_status()
         samples = response.json()["data"]
-        self.logger.debug('Response {samples}')
+        self.logger.debug("Response {samples}")
 
         return [
-            reading for sample in samples
-            for reading in self.__sample_readings(sample)
+            reading for sample in samples for reading in self.__sample_readings(sample)
         ]
 
     def __sample_readings(self, sample):
-        sample_timestamp = int(
-            pyrfc3339.parse(sample["timestamp"]).timestamp()
-        )
+        sample_timestamp = int(pyrfc3339.parse(sample["timestamp"]).timestamp())
 
         return (
             Reading(
                 sensor_name=self.name,
                 name=sensor["comp"],
                 timestamp=sample_timestamp,
-                value=sensor["value"]
+                value=sensor["value"],
             )
             for sensor in sample["sensors"]
         )

--- a/src/snsary/contrib/awair.py
+++ b/src/snsary/contrib/awair.py
@@ -24,13 +24,16 @@ class AwairSensor(PollingSensor):
 
     @classmethod
     def discover_from_env(cls):
-        return cls.discover(token=os.environ["AWAIR_TOKEN"])
+        return cls.discover(
+            token=os.environ["AWAIR_TOKEN"],
+        )
 
     @classmethod
     def discover(cls, *, token):
         get_logger().debug(f"Request {cls.DEVICES_URL}")
         response = requests.get(
-            cls.DEVICES_URL, headers={"Authorization": f"Bearer {token}"}
+            cls.DEVICES_URL,
+            headers={"Authorization": f"Bearer {token}"},
         )
         response.raise_for_status()
         devices = response.json()["devices"]
@@ -71,7 +74,8 @@ class AwairSensor(PollingSensor):
 
         self.logger.debug(f"Request {url}")
         response = requests.get(
-            url, headers={"Authorization": f"Bearer {self.__token}"}
+            url,
+            headers={"Authorization": f"Bearer {self.__token}"},
         )
         response.raise_for_status()
         samples = response.json()["data"]

--- a/src/snsary/contrib/awair.py
+++ b/src/snsary/contrib/awair.py
@@ -85,7 +85,8 @@ class AwairSensor(PollingSensor):
             yield from self.__readings_from_sample(sample)
 
     def __readings_from_sample(self, sample):
-        sample_timestamp = int(pyrfc3339.parse(sample["timestamp"]).timestamp())
+        sample_datetime = pyrfc3339.parse(sample["timestamp"])
+        sample_timestamp = int(sample_datetime.timestamp())
 
         for sensor in sample["sensors"]:
             yield (

--- a/src/snsary/contrib/datastax.py
+++ b/src/snsary/contrib/datastax.py
@@ -78,7 +78,8 @@ class GraphQLOutput(BatchOutput):
             ),
         )
 
-        logging.getLogger("gql").setLevel(logging.WARNING)  # logs per request otherwise
+        # logs per request otherwise
+        logging.getLogger("gql").setLevel(logging.WARNING)
 
         BatchOutput.__init__(self)
         self.__init_schema()

--- a/src/snsary/contrib/datastax.py
+++ b/src/snsary/contrib/datastax.py
@@ -111,11 +111,13 @@ class GraphQLOutput(BatchOutput):
             "value": float(reading.value),
         }
 
+        throwaway_result = self.__dsl.readingMutationResult.value.select(
+            self.__dsl.reading.metric
+        )
+
         return self.__dsl.Mutation.insertreading.args(
             options={"ttl": self.TTL}, value=value
-        ).select(
-            self.__dsl.readingMutationResult.value.select(self.__dsl.reading.metric)
-        )
+        ).select(throwaway_result)
 
     def __init_schema(self):
         with self.__client as session:

--- a/src/snsary/contrib/datastax.py
+++ b/src/snsary/contrib/datastax.py
@@ -73,14 +73,11 @@ class GraphQLOutput(BatchOutput):
     def __init__(self, url, token):
         self.__client = Client(
             transport=RequestsHTTPTransport(
-                url=url,
-                headers={'X-Cassandra-Token': token}
+                url=url, headers={"X-Cassandra-Token": token}
             ),
         )
 
-        logging.getLogger('gql').setLevel(
-            logging.WARNING  # logs per request otherwise
-        )
+        logging.getLogger("gql").setLevel(logging.WARNING)  # logs per request otherwise
 
         BatchOutput.__init__(self)
         self.__init_schema()
@@ -88,13 +85,13 @@ class GraphQLOutput(BatchOutput):
     @classmethod
     def from_env(cls):
         return cls(
-            url=os.environ['DATASTAX_URL'],
-            token=os.environ['DATASTAX_TOKEN'],
+            url=os.environ["DATASTAX_URL"],
+            token=os.environ["DATASTAX_TOKEN"],
         )
 
     def publish_batch(self, readings):
         mutations = list(
-            self.__mutation(reading).alias(f'r{i}')
+            self.__mutation(reading).alias(f"r{i}")
             for i, reading in enumerate(readings)
         )
 
@@ -105,24 +102,22 @@ class GraphQLOutput(BatchOutput):
     def __mutation(self, reading):
         value = {
             # using UTC ensures test stability when run in different zones
-            'timestamp': reading.datetime.astimezone(pytz.utc).isoformat(),
-            'sensor': reading.sensor_name,
-            'host': platform.node(),
-            'metric': reading.name,
-            'value': float(reading.value)
+            "timestamp": reading.datetime.astimezone(pytz.utc).isoformat(),
+            "sensor": reading.sensor_name,
+            "host": platform.node(),
+            "metric": reading.name,
+            "value": float(reading.value),
         }
 
         return self.__dsl.Mutation.insertreading.args(
-            options={'ttl': self.TTL}, value=value
+            options={"ttl": self.TTL}, value=value
         ).select(
-            self.__dsl.readingMutationResult.value.select(
-                self.__dsl.reading.metric
-            )
+            self.__dsl.readingMutationResult.value.select(self.__dsl.reading.metric)
         )
 
     def __init_schema(self):
         with self.__client as session:
             session.fetch_schema()
 
-        self.logger.debug('Initialised schema.')
+        self.logger.debug("Initialised schema.")
         self.__dsl = DSLSchema(self.__client.schema)

--- a/src/snsary/contrib/datastax.py
+++ b/src/snsary/contrib/datastax.py
@@ -73,7 +73,8 @@ class GraphQLOutput(BatchOutput):
     def __init__(self, url, token):
         self.__client = Client(
             transport=RequestsHTTPTransport(
-                url=url, headers={"X-Cassandra-Token": token}
+                url=url,
+                headers={"X-Cassandra-Token": token},
             ),
         )
 

--- a/src/snsary/contrib/google/__init__.py
+++ b/src/snsary/contrib/google/__init__.py
@@ -1,5 +1,3 @@
 from .bigquery import BigQueryOutput
 
-__all__ = [
-    "BigQueryOutput"
-]
+__all__ = ["BigQueryOutput"]

--- a/src/snsary/contrib/google/__init__.py
+++ b/src/snsary/contrib/google/__init__.py
@@ -1,3 +1,5 @@
 from .bigquery import BigQueryOutput
 
-__all__ = ["BigQueryOutput"]
+__all__ = [
+    "BigQueryOutput",
+]

--- a/src/snsary/contrib/google/bigquery.py
+++ b/src/snsary/contrib/google/bigquery.py
@@ -68,13 +68,11 @@ class BigQueryOutput(BatchOutput):
     @classmethod
     def from_env(cls):
         return cls(
-            stream=os.environ['GOOGLE_BIGQUERY_STREAM'],
+            stream=os.environ["GOOGLE_BIGQUERY_STREAM"],
         )
 
     def publish_batch(self, readings):
-        self.__proto_send(
-            [self.__proto_row(reading) for reading in readings]
-        )
+        self.__proto_send([self.__proto_row(reading) for reading in readings])
 
     def __proto_row(self, reading):
         """
@@ -102,9 +100,7 @@ class BigQueryOutput(BatchOutput):
         proto_rows = types.ProtoRows()
 
         for proto_reading in proto_readings:
-            proto_rows.serialized_rows.append(
-                proto_reading.SerializeToString()
-            )
+            proto_rows.serialized_rows.append(proto_reading.SerializeToString())
 
         proto_data = types.AppendRowsRequest.ProtoData()
         proto_data.rows = proto_rows
@@ -115,6 +111,5 @@ class BigQueryOutput(BatchOutput):
         request.proto_rows = proto_data
 
         self.__client.append_rows(
-            requests=iter([request]),
-            retry=Retry(deadline=self.RETRY_DEADLINE)
+            requests=iter([request]), retry=Retry(deadline=self.RETRY_DEADLINE)
         )

--- a/src/snsary/contrib/google/bigquery.py
+++ b/src/snsary/contrib/google/bigquery.py
@@ -72,7 +72,8 @@ class BigQueryOutput(BatchOutput):
         )
 
     def publish_batch(self, readings):
-        self.__proto_send([self.__proto_row(reading) for reading in readings])
+        proto_readings = [self.__proto_row(reading) for reading in readings]
+        self.__proto_send(proto_readings)
 
     def __proto_row(self, reading):
         """
@@ -100,7 +101,9 @@ class BigQueryOutput(BatchOutput):
         proto_rows = types.ProtoRows()
 
         for proto_reading in proto_readings:
-            proto_rows.serialized_rows.append(proto_reading.SerializeToString())
+            proto_rows.serialized_rows.append(
+                proto_reading.SerializeToString(),
+            )
 
         proto_data = types.AppendRowsRequest.ProtoData()
         proto_data.rows = proto_rows
@@ -111,5 +114,6 @@ class BigQueryOutput(BatchOutput):
         request.proto_rows = proto_data
 
         self.__client.append_rows(
-            requests=iter([request]), retry=Retry(deadline=self.RETRY_DEADLINE)
+            requests=iter([request]),
+            retry=Retry(deadline=self.RETRY_DEADLINE),
         )

--- a/src/snsary/contrib/google/reading_pb2.py
+++ b/src/snsary/contrib/google/reading_pb2.py
@@ -13,23 +13,26 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
+    b'\n\ntest.proto\x12\x06snsary"Y\n\x07Reading\x12\x0c\n\x04host\x18\x01 \x02(\t\x12\x0e\n\x06sensor\x18\x02 \x02(\t\x12\x0e\n\x06metric\x18\x03 \x02(\t\x12\x11\n\ttimestamp\x18\x04 \x02(\t\x12\r\n\x05value\x18\x05 \x02(\x01'
+)
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\ntest.proto\x12\x06snsary\"Y\n\x07Reading\x12\x0c\n\x04host\x18\x01 \x02(\t\x12\x0e\n\x06sensor\x18\x02 \x02(\t\x12\x0e\n\x06metric\x18\x03 \x02(\t\x12\x11\n\ttimestamp\x18\x04 \x02(\t\x12\r\n\x05value\x18\x05 \x02(\x01')
-
-
-
-_READING = DESCRIPTOR.message_types_by_name['Reading']
-Reading = _reflection.GeneratedProtocolMessageType('Reading', (_message.Message,), {
-  'DESCRIPTOR' : _READING,
-  '__module__' : 'test_pb2'
-  # @@protoc_insertion_point(class_scope:snsary.Reading)
-  })
+_READING = DESCRIPTOR.message_types_by_name["Reading"]
+Reading = _reflection.GeneratedProtocolMessageType(
+    "Reading",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _READING,
+        "__module__": "test_pb2"
+        # @@protoc_insertion_point(class_scope:snsary.Reading)
+    },
+)
 _sym_db.RegisterMessage(Reading)
 
 if _descriptor._USE_C_DESCRIPTORS == False:
 
-  DESCRIPTOR._options = None
-  _READING._serialized_start=22
-  _READING._serialized_end=111
+    DESCRIPTOR._options = None
+    _READING._serialized_start = 22
+    _READING._serialized_end = 111
 # @@protoc_insertion_point(module_scope)

--- a/src/snsary/contrib/grafana.py
+++ b/src/snsary/contrib/grafana.py
@@ -16,10 +16,7 @@ from snsary.outputs import BatchOutput
 class GraphiteOutput(BatchOutput):
     @classmethod
     def from_env(cls):
-        return cls(
-            url=os.environ['GRAPHITE_URL'],
-            prefix=platform.node()
-        )
+        return cls(url=os.environ["GRAPHITE_URL"], prefix=platform.node())
 
     def __init__(self, *, url, prefix):
         BatchOutput.__init__(self)
@@ -33,18 +30,21 @@ class GraphiteOutput(BatchOutput):
         response = requests.post(
             self.__url,
             data=data,
-            headers={'Content-Type': 'application/json'},
+            headers={"Content-Type": "application/json"},
         )
 
         self.logger.debug(response.text)
         response.raise_for_status()
 
     def __format(self, readings):
-        return json.dumps([
-            {
-                'name': f'{self.__prefix}.{reading.sensor_name}.{reading.name}',
-                'value': reading.value,
-                'time': reading.timestamp,
-                'interval': 1
-            } for reading in readings
-        ])
+        return json.dumps(
+            [
+                {
+                    "name": f"{self.__prefix}.{reading.sensor_name}.{reading.name}",
+                    "value": reading.value,
+                    "time": reading.timestamp,
+                    "interval": 1,
+                }
+                for reading in readings
+            ]
+        )

--- a/src/snsary/contrib/grafana.py
+++ b/src/snsary/contrib/grafana.py
@@ -16,7 +16,10 @@ from snsary.outputs import BatchOutput
 class GraphiteOutput(BatchOutput):
     @classmethod
     def from_env(cls):
-        return cls(url=os.environ["GRAPHITE_URL"], prefix=platform.node())
+        return cls(
+            url=os.environ["GRAPHITE_URL"],
+            prefix=platform.node(),
+        )
 
     def __init__(self, *, url, prefix):
         BatchOutput.__init__(self)

--- a/src/snsary/contrib/influxdb.py
+++ b/src/snsary/contrib/influxdb.py
@@ -44,8 +44,7 @@ class InfluxDBOutput(BatchOutput):
             for reading in readings
         ]
 
-        self.logger.debug(
-            "Sending " + str(list(point.to_line_protocol() for point in points))
-        )
+        lines = [point.to_line_protocol() for point in points]
+        self.logger.debug("Sending " + str(lines))
 
         self.__write_api.write(bucket=self.__bucket, record=points)

--- a/src/snsary/contrib/influxdb.py
+++ b/src/snsary/contrib/influxdb.py
@@ -22,10 +22,10 @@ class InfluxDBOutput(BatchOutput):
     @classmethod
     def from_env(cls):
         return cls(
-            url=os.environ['INFLUXDB_URL'],
-            token=os.environ['INFLUXDB_TOKEN'],
-            org=os.environ['INFLUXDB_ORG'],
-            bucket=os.environ['INFLUXDB_BUCKET']
+            url=os.environ["INFLUXDB_URL"],
+            token=os.environ["INFLUXDB_TOKEN"],
+            org=os.environ["INFLUXDB_ORG"],
+            bucket=os.environ["INFLUXDB_BUCKET"],
         )
 
     def __init__(self, *, url, token, org, bucket):
@@ -37,17 +37,15 @@ class InfluxDBOutput(BatchOutput):
     def publish_batch(self, readings):
         points = [
             Point(reading.name)
-            .tag('sensor', reading.sensor_name)
-            .tag('host', platform.node())
-            .field('value', reading.value)
-            .time(reading.timestamp, write_precision='s')
+            .tag("sensor", reading.sensor_name)
+            .tag("host", platform.node())
+            .field("value", reading.value)
+            .time(reading.timestamp, write_precision="s")
             for reading in readings
         ]
 
-        self.logger.debug('Sending ' + str(list(
-            point.to_line_protocol() for point in points
-        )))
-
-        self.__write_api.write(
-            bucket=self.__bucket, record=points
+        self.logger.debug(
+            "Sending " + str(list(point.to_line_protocol() for point in points))
         )
+
+        self.__write_api.write(bucket=self.__bucket, record=points)

--- a/src/snsary/contrib/octopus.py
+++ b/src/snsary/contrib/octopus.py
@@ -57,9 +57,10 @@ class OctopusSensor(PollingSensor):
         samples = response.json()["results"]
         self.logger.debug(f"Response {samples}")
 
-        return [self.__sample_reading(sample) for sample in samples]
+        for sample in samples:
+            yield self.__reading_from_sample(sample)
 
-    def __sample_reading(self, sample):
+    def __reading_from_sample(self, sample):
         sample_timestamp = int(pyrfc3339.parse(sample["interval_end"]).timestamp())
 
         return Reading(

--- a/src/snsary/contrib/octopus.py
+++ b/src/snsary/contrib/octopus.py
@@ -61,7 +61,8 @@ class OctopusSensor(PollingSensor):
             yield self.__reading_from_sample(sample)
 
     def __reading_from_sample(self, sample):
-        sample_timestamp = int(pyrfc3339.parse(sample["interval_end"]).timestamp())
+        sample_datetime = pyrfc3339.parse(sample["interval_end"])
+        sample_timestamp = int(sample_datetime.timestamp())
 
         return Reading(
             sensor_name=self.name,

--- a/src/snsary/contrib/octopus.py
+++ b/src/snsary/contrib/octopus.py
@@ -28,7 +28,10 @@ class OctopusSensor(PollingSensor):
         )
 
     def __init__(self, *, mpan, serial_number, token):
-        PollingSensor.__init__(self, period_seconds=30 * 60)  # 30 mins
+        PollingSensor.__init__(
+            self,
+            period_seconds=30 * 60,  # 30 mins
+        )
 
         self.__token = token
         self.__mpan = mpan

--- a/src/snsary/contrib/octopus.py
+++ b/src/snsary/contrib/octopus.py
@@ -22,16 +22,13 @@ class OctopusSensor(PollingSensor):
     @classmethod
     def from_env(cls):
         return cls(
-            mpan=os.environ['OCTOPUS_MPAN'],
-            serial_number=os.environ['OCTOPUS_SERIAL'],
-            token=os.environ['OCTOPUS_TOKEN']
+            mpan=os.environ["OCTOPUS_MPAN"],
+            serial_number=os.environ["OCTOPUS_SERIAL"],
+            token=os.environ["OCTOPUS_TOKEN"],
         )
 
     def __init__(self, *, mpan, serial_number, token):
-        PollingSensor.__init__(
-            self,
-            period_seconds=30 * 60  # 30 mins
-        )
+        PollingSensor.__init__(self, period_seconds=30 * 60)  # 30 mins
 
         self.__token = token
         self.__mpan = mpan
@@ -39,7 +36,7 @@ class OctopusSensor(PollingSensor):
 
     @property
     def name(self):
-        return 'octopus'
+        return "octopus"
 
     def sample(self, now, **kwargs):
         start = now - timedelta(days=1)
@@ -48,29 +45,23 @@ class OctopusSensor(PollingSensor):
         url = self.CONSUMPTION_URL.format(
             mpan=self.__mpan,
             serial_number=self.__serial_number,
-            period_from=pyrfc3339.generate(start)
+            period_from=pyrfc3339.generate(start),
         )
 
-        self.logger.debug(f'Request {url}')
-        response = requests.get(
-            url, auth=(self.__token, '')
-        )
+        self.logger.debug(f"Request {url}")
+        response = requests.get(url, auth=(self.__token, ""))
         response.raise_for_status()
         samples = response.json()["results"]
-        self.logger.debug(f'Response {samples}')
+        self.logger.debug(f"Response {samples}")
 
-        return [
-            self.__sample_reading(sample) for sample in samples
-        ]
+        return [self.__sample_reading(sample) for sample in samples]
 
     def __sample_reading(self, sample):
-        sample_timestamp = int(
-            pyrfc3339.parse(sample["interval_end"]).timestamp()
-        )
+        sample_timestamp = int(pyrfc3339.parse(sample["interval_end"]).timestamp())
 
         return Reading(
             sensor_name=self.name,
-            name='consumption',
+            name="consumption",
             timestamp=sample_timestamp,
             value=sample["consumption"],
         )

--- a/src/snsary/contrib/pimoroni.py
+++ b/src/snsary/contrib/pimoroni.py
@@ -57,6 +57,11 @@ class GenericSensor(PollingSensor):
 
     def sample(self, timestamp, **kwargs):
         return [
-            Reading(sensor_name=self.name, name=name, value=value, timestamp=timestamp)
+            Reading(
+                sensor_name=self.name,
+                name=name,
+                value=value,
+                timestamp=timestamp,
+            )
             for name, value in self.__read_fn()
         ]

--- a/src/snsary/contrib/pimoroni.py
+++ b/src/snsary/contrib/pimoroni.py
@@ -28,21 +28,22 @@ class GenericSensor(PollingSensor):
 
         # data is stored as slots in reading
         from mics6814 import Mics6814Reading
+
         class_scraper = scraper.for_class(Mics6814Reading)
 
         # create once to avoid descriptor leak
         from mics6814 import MICS6814
+
         instance = MICS6814()
 
         # turn off bright LED (on by default)
         instance.set_led(0, 0, 0)
 
         return cls(
-            name='MICS6814',
+            name="MICS6814",
             read_fn=lambda: filter(
-                lambda scrap: scrap[0] != 'adc',
-                class_scraper(instance.read_all())
-            )
+                lambda scrap: scrap[0] != "adc", class_scraper(instance.read_all())
+            ),
         )
 
     def __init__(self, *, name, read_fn):
@@ -56,11 +57,6 @@ class GenericSensor(PollingSensor):
 
     def sample(self, timestamp, **kwargs):
         return [
-            Reading(
-                sensor_name=self.name,
-                name=name,
-                value=value,
-                timestamp=timestamp
-            )
+            Reading(sensor_name=self.name, name=name, value=value, timestamp=timestamp)
             for name, value in self.__read_fn()
         ]

--- a/src/snsary/contrib/pimoroni.py
+++ b/src/snsary/contrib/pimoroni.py
@@ -39,12 +39,12 @@ class GenericSensor(PollingSensor):
         # turn off bright LED (on by default)
         instance.set_led(0, 0, 0)
 
-        return cls(
-            name="MICS6814",
-            read_fn=lambda: filter(
-                lambda scrap: scrap[0] != "adc", class_scraper(instance.read_all())
-            ),
-        )
+        def read_fn():
+            scraps = class_scraper(instance.read_all())
+            # filter out internal "adc" resistance values
+            return filter(lambda scrap: scrap[0] != "adc", scraps)
+
+        return cls(name="MICS6814", read_fn=read_fn)
 
     def __init__(self, *, name, read_fn):
         PollingSensor.__init__(self, period_seconds=10)

--- a/src/snsary/contrib/psutil.py
+++ b/src/snsary/contrib/psutil.py
@@ -7,19 +7,19 @@ from snsary.utils import scraper
 
 class PSUtilSensor(PollingSensor):
     FUNCTIONS = {
-        'cpu_times': {},
-        'cpu_percent': {'interval': 1},
-        'cpu_count': {},
-        'cpu_stats': {},
-        'getloadavg': {},
-        'virtual_memory': {},
-        'swap_memory': {},
-        'disk_usage': {'path': '/'},
-        'disk_io_counter': {},
-        'net_io_counters': {},
-        'sensors_temperatures': {},
-        'sensors_fans': {},
-        'sensors_battery': {},
+        "cpu_times": {},
+        "cpu_percent": {"interval": 1},
+        "cpu_count": {},
+        "cpu_stats": {},
+        "getloadavg": {},
+        "virtual_memory": {},
+        "swap_memory": {},
+        "disk_usage": {"path": "/"},
+        "disk_io_counter": {},
+        "net_io_counters": {},
+        "sensors_temperatures": {},
+        "sensors_fans": {},
+        "sensors_battery": {},
     }
 
     def __init__(self, functions=FUNCTIONS):
@@ -28,16 +28,11 @@ class PSUtilSensor(PollingSensor):
 
     @property
     def name(self):
-        return 'psutil'
+        return "psutil"
 
     def sample(self, timestamp, **kwargs):
         return [
-            Reading(
-                sensor_name=self.name,
-                name=name,
-                value=value,
-                timestamp=timestamp
-            )
+            Reading(sensor_name=self.name, name=name, value=value, timestamp=timestamp)
             for fname, kwargs in self.__functions.items()
             for (name, value) in self.__sample_fn(fname, kwargs)
         ]
@@ -48,5 +43,5 @@ class PSUtilSensor(PollingSensor):
             return []
 
         value = getattr(psutil, fname)(**kwargs)
-        self.logger.debug(f'Scraping {fname} => {value}')
+        self.logger.debug(f"Scraping {fname} => {value}")
         return scraper.extract_from(value, prefix=fname)

--- a/src/snsary/contrib/pypms.py
+++ b/src/snsary/contrib/pypms.py
@@ -20,7 +20,12 @@ class PyPMSSensor(PollingSensor):
     """
 
     def __init__(
-        self, *, sensor_name, port="/dev/ttyS0", warm_up_seconds=10, timeout=5
+        self,
+        *,
+        sensor_name,
+        port="/dev/ttyS0",
+        warm_up_seconds=10,
+        timeout=5,
     ):
         self.__sensor = Sensor[sensor_name]
         self.warm_up_seconds = warm_up_seconds
@@ -31,7 +36,10 @@ class PyPMSSensor(PollingSensor):
             timeout=timeout,
         )
 
-        PollingSensor.__init__(self, period_seconds=10)
+        PollingSensor.__init__(
+            self,
+            period_seconds=10,
+        )
 
     @property
     def name(self):
@@ -77,7 +85,12 @@ class PyPMSSensor(PollingSensor):
         obs = self.__sensor.decode(buffer)
 
         return [
-            Reading(sensor_name=self.name, name=key, value=value, timestamp=timestamp)
+            Reading(
+                sensor_name=self.name,
+                name=key,
+                value=value,
+                timestamp=timestamp,
+            )
             for key, value in dataclasses.asdict(obs).items()
             if key not in ("time")
         ]

--- a/src/snsary/contrib/pypms.py
+++ b/src/snsary/contrib/pypms.py
@@ -18,13 +18,9 @@ class PyPMSSensor(PollingSensor):
     """
     ``warm_up_seconds`` is necessary for some sensors e.g. for the PMSA003 the first two samples always `raise an InconsistentObservation exception <https://github.com/avaldebe/PyPMS/blob/04ff8edede7d780018cd00a7fcf78ffed43c0de4/src/pms/sensors/plantower/pmsx003.py#L63>`_.
     """
+
     def __init__(
-        self,
-        *,
-        sensor_name,
-        port='/dev/ttyS0',
-        warm_up_seconds=10,
-        timeout=5
+        self, *, sensor_name, port="/dev/ttyS0", warm_up_seconds=10, timeout=5
     ):
         self.__sensor = Sensor[sensor_name]
         self.warm_up_seconds = warm_up_seconds
@@ -35,10 +31,7 @@ class PyPMSSensor(PollingSensor):
             timeout=timeout,
         )
 
-        PollingSensor.__init__(
-            self,
-            period_seconds=10
-        )
+        PollingSensor.__init__(self, period_seconds=10)
 
     @property
     def name(self):
@@ -84,12 +77,7 @@ class PyPMSSensor(PollingSensor):
         obs = self.__sensor.decode(buffer)
 
         return [
-            Reading(
-                sensor_name=self.name,
-                name=key,
-                value=value,
-                timestamp=timestamp
-            )
+            Reading(sensor_name=self.name, name=key, value=value, timestamp=timestamp)
             for key, value in dataclasses.asdict(obs).items()
-            if key not in ('time')
+            if key not in ("time")
         ]

--- a/src/snsary/functions/__init__.py
+++ b/src/snsary/functions/__init__.py
@@ -9,11 +9,4 @@ from .window import Window
 from .window_average import WindowAverage
 from .window_summary import WindowSummary
 
-__all__ = [
-    "Filter",
-    "Window",
-    "WindowAverage",
-    "Function",
-    "WindowSummary",
-    "Rename"
-]
+__all__ = ["Filter", "Window", "WindowAverage", "Function", "WindowSummary", "Rename"]

--- a/src/snsary/functions/__init__.py
+++ b/src/snsary/functions/__init__.py
@@ -9,4 +9,11 @@ from .window import Window
 from .window_average import WindowAverage
 from .window_summary import WindowSummary
 
-__all__ = ["Filter", "Window", "WindowAverage", "Function", "WindowSummary", "Rename"]
+__all__ = [
+    "Filter",
+    "Window",
+    "WindowAverage",
+    "Function",
+    "WindowSummary",
+    "Rename",
+]

--- a/src/snsary/functions/filter.py
+++ b/src/snsary/functions/filter.py
@@ -14,12 +14,8 @@ class Filter(Function):
 
     @classmethod
     def sensor_name(cls, name):
-        return cls(
-            lambda reading: reading.sensor_name == name
-        )
+        return cls(lambda reading: reading.sensor_name == name)
 
     @classmethod
     def names(cls, *names):
-        return cls(
-            lambda reading: reading.name in names
-        )
+        return cls(lambda reading: reading.name in names)

--- a/src/snsary/functions/rename.py
+++ b/src/snsary/functions/rename.py
@@ -11,7 +11,7 @@ from .function import Function
 
 
 class Rename(Function):
-    def __init__(self, append='', to=None):
+    def __init__(self, append="", to=None):
         self.__append = append
         self.__to = to
 

--- a/src/snsary/functions/window.py
+++ b/src/snsary/functions/window.py
@@ -55,4 +55,4 @@ class Window(Function, Service):
         raise NotImplementedError()
 
     def key(self, reading):
-        return f'window-{int(self.__period)}-{reading.sensor_name}-{reading.name}'
+        return f"window-{int(self.__period)}-{reading.sensor_name}-{reading.name}"

--- a/src/snsary/functions/window_average.py
+++ b/src/snsary/functions/window_average.py
@@ -9,4 +9,5 @@ from .window import Window
 
 class WindowAverage(Window):
     def aggregate(self, readings):
-        return [readings[-1].dup(value=mean(r.value for r in readings))]
+        aggregate_value = mean(r.value for r in readings)
+        return [readings[-1].dup(value=aggregate_value)]

--- a/src/snsary/functions/window_average.py
+++ b/src/snsary/functions/window_average.py
@@ -9,6 +9,4 @@ from .window import Window
 
 class WindowAverage(Window):
     def aggregate(self, readings):
-        return [readings[-1].dup(
-            value=mean(r.value for r in readings)
-        )]
+        return [readings[-1].dup(value=mean(r.value for r in readings))]

--- a/src/snsary/functions/window_summary.py
+++ b/src/snsary/functions/window_summary.py
@@ -10,16 +10,13 @@ from .window import Window
 class WindowSummary(Window):
     def aggregate(self, readings):
         def __dup_reading(name, value):
-            return readings[-1].dup(
-                name=readings[-1].name + f'--{name}',
-                value=value
-            )
+            return readings[-1].dup(name=readings[-1].name + f"--{name}", value=value)
 
         values = [r.value for r in readings]
 
         return [
-            __dup_reading('mean', mean(values)),
-            __dup_reading('max', max(values)),
-            __dup_reading('min', min(values)),
-            __dup_reading('p50', median(values))
+            __dup_reading("mean", mean(values)),
+            __dup_reading("max", max(values)),
+            __dup_reading("min", min(values)),
+            __dup_reading("p50", median(values)),
         ]

--- a/src/snsary/functions/window_summary.py
+++ b/src/snsary/functions/window_summary.py
@@ -10,7 +10,12 @@ from .window import Window
 class WindowSummary(Window):
     def aggregate(self, readings):
         def __dup_reading(name, value):
-            return readings[-1].dup(name=readings[-1].name + f"--{name}", value=value)
+            base_reading = readings[-1]
+
+            return base_reading.dup(
+                name=base_reading.name + f"--{name}",
+                value=value,
+            )
 
         values = [r.value for r in readings]
 

--- a/src/snsary/models/reading.py
+++ b/src/snsary/models/reading.py
@@ -29,7 +29,7 @@ class Reading:
         return datetime.fromtimestamp(self.timestamp).astimezone()
 
     def __str__(self):
-        return f'<{self.name} {self.timestamp} {self.value}>'
+        return f"<{self.name} {self.timestamp} {self.value}>"
 
     def dup(self, **kwargs):
         source = dict(

--- a/src/snsary/outputs/__init__.py
+++ b/src/snsary/outputs/__init__.py
@@ -6,8 +6,4 @@ from .batch_output import BatchOutput
 from .mock_output import MockOutput
 from .output import Output
 
-__all__ = [
-    "BatchOutput",
-    "MockOutput",
-    "Output"
-]
+__all__ = ["BatchOutput", "MockOutput", "Output"]

--- a/src/snsary/outputs/__init__.py
+++ b/src/snsary/outputs/__init__.py
@@ -6,4 +6,8 @@ from .batch_output import BatchOutput
 from .mock_output import MockOutput
 from .output import Output
 
-__all__ = ["BatchOutput", "MockOutput", "Output"]
+__all__ = [
+    "BatchOutput",
+    "MockOutput",
+    "Output",
+]

--- a/src/snsary/outputs/mock_output.py
+++ b/src/snsary/outputs/mock_output.py
@@ -6,13 +6,7 @@ from .output import Output
 
 
 class MockOutput(Output):
-    def __init__(
-        self,
-        *,
-        fail=False,
-        hang=False,
-        index=0
-    ):
+    def __init__(self, *, fail=False, hang=False, index=0):
         self.__fail = fail
         self.__hang = hang
         self.__failures = 0
@@ -20,7 +14,7 @@ class MockOutput(Output):
 
     @property
     def logger(self):
-        return get_logger(f'mockoutput-{self.__index}')
+        return get_logger(f"mockoutput-{self.__index}")
 
     def publish(self, reading):
         if self.__hang:
@@ -28,6 +22,6 @@ class MockOutput(Output):
 
         if self.__fail:
             self.__failures += 1
-            raise RuntimeError(f'problem-{self.__failures}')
+            raise RuntimeError(f"problem-{self.__failures}")
 
         self.logger.info(f"Reading: {reading}")

--- a/src/snsary/outputs/mock_output.py
+++ b/src/snsary/outputs/mock_output.py
@@ -6,7 +6,13 @@ from .output import Output
 
 
 class MockOutput(Output):
-    def __init__(self, *, fail=False, hang=False, index=0):
+    def __init__(
+        self,
+        *,
+        fail=False,
+        hang=False,
+        index=0,
+    ):
         self.__fail = fail
         self.__hang = hang
         self.__failures = 0

--- a/src/snsary/sources/__init__.py
+++ b/src/snsary/sources/__init__.py
@@ -4,10 +4,4 @@ from .polling_sensor import PollingSensor
 from .sensor import Sensor
 from .source import Source
 
-__all__ = [
-    "MockSensor",
-    "PollingSensor",
-    "Sensor",
-    "Source",
-    "MultiSource"
-]
+__all__ = ["MockSensor", "PollingSensor", "Sensor", "Source", "MultiSource"]

--- a/src/snsary/sources/__init__.py
+++ b/src/snsary/sources/__init__.py
@@ -4,4 +4,10 @@ from .polling_sensor import PollingSensor
 from .sensor import Sensor
 from .source import Source
 
-__all__ = ["MockSensor", "PollingSensor", "Sensor", "Source", "MultiSource"]
+__all__ = [
+    "MockSensor",
+    "PollingSensor",
+    "Sensor",
+    "Source",
+    "MultiSource",
+]

--- a/src/snsary/sources/mock_sensor.py
+++ b/src/snsary/sources/mock_sensor.py
@@ -6,8 +6,18 @@ from .polling_sensor import PollingSensor
 
 
 class MockSensor(PollingSensor):
-    def __init__(self, *, fail=False, hang=False, period_seconds=5, index=0):
-        PollingSensor.__init__(self, period_seconds=period_seconds)
+    def __init__(
+        self,
+        *,
+        fail=False,
+        hang=False,
+        period_seconds=5,
+        index=0,
+    ):
+        PollingSensor.__init__(
+            self,
+            period_seconds=period_seconds,
+        )
 
         self.__hang = hang
         self.__fail = fail
@@ -19,7 +29,11 @@ class MockSensor(PollingSensor):
         return f"mocksensor-{self.__index}"
 
     def sample(
-        self, now, start_time, timestamp, elapsed_seconds  # unused here  # unused here
+        self,
+        now,  # unused here (implicit test for kwarg)
+        start_time,  # unused (implicitly kwarg check)
+        timestamp,
+        elapsed_seconds,
     ):
         if self.__fail:
             self.__failures += 1

--- a/src/snsary/sources/mock_sensor.py
+++ b/src/snsary/sources/mock_sensor.py
@@ -6,18 +6,8 @@ from .polling_sensor import PollingSensor
 
 
 class MockSensor(PollingSensor):
-    def __init__(
-        self,
-        *,
-        fail=False,
-        hang=False,
-        period_seconds=5,
-        index=0
-    ):
-        PollingSensor.__init__(
-            self,
-            period_seconds=period_seconds
-        )
+    def __init__(self, *, fail=False, hang=False, period_seconds=5, index=0):
+        PollingSensor.__init__(self, period_seconds=period_seconds)
 
         self.__hang = hang
         self.__fail = fail
@@ -26,18 +16,14 @@ class MockSensor(PollingSensor):
 
     @property
     def name(self):
-        return f'mocksensor-{self.__index}'
+        return f"mocksensor-{self.__index}"
 
     def sample(
-        self,
-        now,  # unused here
-        start_time,  # unused here
-        timestamp,
-        elapsed_seconds
+        self, now, start_time, timestamp, elapsed_seconds  # unused here  # unused here
     ):
         if self.__fail:
             self.__failures += 1
-            raise RuntimeError(f'problem-{self.__failures}')
+            raise RuntimeError(f"problem-{self.__failures}")
 
         if self.__hang:
             Event().wait()
@@ -45,7 +31,7 @@ class MockSensor(PollingSensor):
         return [
             Reading(
                 sensor_name=self.name,
-                name='abc',
+                name="abc",
                 timestamp=timestamp,
                 value=elapsed_seconds,
             )

--- a/src/snsary/sources/multi_source.py
+++ b/src/snsary/sources/multi_source.py
@@ -10,6 +10,7 @@ from .source import Source
 class MultiSource(Source):
     def __init__(self, *sources):
         from snsary.streams import AsyncStream
+
         self.__stream = AsyncStream()
 
         for source in sources:

--- a/src/snsary/sources/sensor.py
+++ b/src/snsary/sources/sensor.py
@@ -4,6 +4,7 @@ from .source import Source
 class Sensor(Source):
     def __init__(self):
         from snsary.streams import AsyncStream
+
         self.__stream = AsyncStream()
 
     @property

--- a/src/snsary/streams/__init__.py
+++ b/src/snsary/streams/__init__.py
@@ -28,4 +28,8 @@ from .async_stream import AsyncStream
 from .simple_stream import SimpleStream
 from .stream import Stream
 
-__all__ = ["SimpleStream", "AsyncStream", "Stream"]
+__all__ = [
+    "SimpleStream",
+    "AsyncStream",
+    "Stream",
+]

--- a/src/snsary/streams/__init__.py
+++ b/src/snsary/streams/__init__.py
@@ -28,8 +28,4 @@ from .async_stream import AsyncStream
 from .simple_stream import SimpleStream
 from .stream import Stream
 
-__all__ = [
-    "SimpleStream",
-    "AsyncStream",
-    "Stream"
-]
+__all__ = ["SimpleStream", "AsyncStream", "Stream"]

--- a/src/snsary/streams/func_stream.py
+++ b/src/snsary/streams/func_stream.py
@@ -7,7 +7,11 @@ from .simple_stream import SimpleStream
 
 
 class FuncStream(SimpleStream):
-    def __init__(self, stream, function=lambda reading: [reading]):
+    def __init__(
+        self,
+        stream,
+        function=lambda reading: [reading],
+    ):
         SimpleStream.__init__(self)
         stream.subscribe(self)
         self.__function = function

--- a/src/snsary/streams/func_stream.py
+++ b/src/snsary/streams/func_stream.py
@@ -7,11 +7,7 @@ from .simple_stream import SimpleStream
 
 
 class FuncStream(SimpleStream):
-    def __init__(
-        self,
-        stream,
-        function=lambda reading: [reading]
-    ):
+    def __init__(self, stream, function=lambda reading: [reading]):
         SimpleStream.__init__(self)
         stream.subscribe(self)
         self.__function = function

--- a/src/snsary/streams/stream.py
+++ b/src/snsary/streams/stream.py
@@ -17,6 +17,7 @@ class Stream(Source, Output):
 
     def apply(self, function):
         from .func_stream import FuncStream
+
         return FuncStream(self, function)
 
     def filter_names(self, *names):

--- a/src/snsary/system.py
+++ b/src/snsary/system.py
@@ -18,12 +18,12 @@ def start_and_wait():
 
 
 def stop(*_):
-    get_logger().info('Stopping.')
+    get_logger().info("Stopping.")
 
     for service in Service.instances:
         __stop_service(service)
 
-    get_logger().info('Bye.')
+    get_logger().info("Bye.")
 
 
 def wait(*, handle_signals=True):

--- a/src/snsary/utils/__init__.py
+++ b/src/snsary/utils/__init__.py
@@ -12,5 +12,5 @@ __all__ = [
     "Service",
     "get_logger",
     "HasLogger",
-    "get_storage"
+    "get_storage",
 ]

--- a/src/snsary/utils/logger.py
+++ b/src/snsary/utils/logger.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from threading import current_thread, main_thread
 
-rootLogger = logging.getLogger('snsary')
+rootLogger = logging.getLogger("snsary")
 loggers = dict()
 
 
@@ -20,7 +20,7 @@ def get_logger(name=None):
     thread_id = current_thread().ident
 
     if name:
-        sublogger = logging.getLogger(f'snsary.{name}')
+        sublogger = logging.getLogger(f"snsary.{name}")
         loggers[thread_id] = sublogger
         return sublogger
 
@@ -30,12 +30,10 @@ def get_logger(name=None):
     if thread_id in loggers:
         return loggers[thread_id]
 
-    return logging.getLogger(f'snsary.anon-{thread_id}')
+    return logging.getLogger(f"snsary.anon-{thread_id}")
 
 
 def configure_logging(level=logging.INFO):
     logging.basicConfig(
-        stream=sys.stdout,
-        level=level,
-        format="%(levelname)s - [%(name)s] %(message)s"
+        stream=sys.stdout, level=level, format="%(levelname)s - [%(name)s] %(message)s"
     )

--- a/src/snsary/utils/logger.py
+++ b/src/snsary/utils/logger.py
@@ -35,5 +35,7 @@ def get_logger(name=None):
 
 def configure_logging(level=logging.INFO):
     logging.basicConfig(
-        stream=sys.stdout, level=level, format="%(levelname)s - [%(name)s] %(message)s"
+        stream=sys.stdout,
+        level=level,
+        format="%(levelname)s - [%(name)s] %(message)s",
     )

--- a/src/snsary/utils/poller.py
+++ b/src/snsary/utils/poller.py
@@ -45,5 +45,5 @@ class Poller(Service):
             "now": now,
             "start_time": self.__start_time,
             "timestamp": int(now.timestamp()),
-            "elapsed_seconds": int((now - self.__start_time).total_seconds())
+            "elapsed_seconds": int((now - self.__start_time).total_seconds()),
         }

--- a/src/snsary/utils/scraper.py
+++ b/src/snsary/utils/scraper.py
@@ -6,14 +6,14 @@ from .logger import get_logger
 def extract_from(value, *, prefix):
     if isinstance(value, dict):
         for key, item in value.items():
-            yield from extract_from(item, prefix=f'{prefix}-{key}')
+            yield from extract_from(item, prefix=f"{prefix}-{key}")
 
-    elif hasattr(value, '_asdict'):
+    elif hasattr(value, "_asdict"):
         yield from extract_from(value._asdict(), prefix=prefix)
 
     elif isinstance(value, (tuple, list)):
         for index, item in enumerate(value):
-            yield from extract_from(item, prefix=f'{prefix}-{index}')
+            yield from extract_from(item, prefix=f"{prefix}-{index}")
 
     elif isinstance(value, int):
         yield (prefix, int(value))
@@ -28,9 +28,10 @@ def extract_from(value, *, prefix):
 class for_class:
     def __init__(self, klass):
         self.__props = [
-            name for name, value in vars(klass).items()
+            name
+            for name, value in vars(klass).items()
             if isinstance(value, (property, member_descriptor))
-            and not name.startswith('_')
+            and not name.startswith("_")
         ]
 
     def __call__(self, instance):

--- a/src/snsary/utils/storage.py
+++ b/src/snsary/utils/storage.py
@@ -40,30 +40,30 @@ def get_storage():
 
 
 def _get_storage_backend():
-    path = os.environ.get('STORAGE_PATH', '')
+    path = os.environ.get("STORAGE_PATH", "")
 
     if not path:
-        get_logger().debug('Using memory store.')
+        get_logger().debug("Using memory store.")
         return dict()
 
-    get_logger().debug(f'Using store {path}.')
-    ttl = os.environ.get('STORAGE_TTL', 86400)
+    get_logger().debug(f"Using store {path}.")
+    ttl = os.environ.get("STORAGE_TTL", 86400)
 
-    get_logger().debug(f'Store TTL set to {ttl}.')
+    get_logger().debug(f"Store TTL set to {ttl}.")
     return _get_file_backend(path, int(ttl))
 
 
 def _get_file_backend(path, ttl):
     try:
-        cache = pickle.load(open(path, 'rb'))
+        cache = pickle.load(open(path, "rb"))
     except Exception:
-        get_logger().debug(f'{path} not found.')
-        get_logger().debug('Creating new store.')
-        cache = TTLCache(float('inf'), ttl)
+        get_logger().debug(f"{path} not found.")
+        get_logger().debug("Creating new store.")
+        cache = TTLCache(float("inf"), ttl)
 
     def atexit_handler():
-        get_logger().debug(f'Writing store {path}.')
-        pickle.dump(cache, open(path, 'wb'))
+        get_logger().debug(f"Writing store {path}.")
+        pickle.dump(cache, open(path, "wb"))
 
     atexit.register(atexit_handler)
     return cache

--- a/src/snsary/utils/tracker.py
+++ b/src/snsary/utils/tracker.py
@@ -56,7 +56,6 @@ class Tracker(HasLogger, HasStore):
 class MaxTracker(Tracker):
     def __init__(self, id, *, names, on_change):
         self.on_change = on_change
-
         Tracker.__init__(self, id, **{name: max for name in names})
 
 

--- a/src/snsary/utils/tracker.py
+++ b/src/snsary/utils/tracker.py
@@ -3,7 +3,7 @@ Utility to track the values of readings with specified names using persistent :m
 
     Tracker('id-for-persistent-storage', myreading=max, othername=min)
 
-Call ``update`` when new readings are available. ``on_change`` is called when one or more tracked values change - set to a different function to subscribe to changes.
+Call ``update`` when new readings are available. ``on_change`` is called with kwargs ``old`` and ``new`` when one or more tracked values change - set to a different function to subscribe to changes.
 """
 
 from .logger import HasLogger
@@ -19,7 +19,7 @@ class Tracker(HasLogger, HasStore):
     def values(self):
         return self.store.get(f"{self.__id}-tracked-values", {})
 
-    def on_change(self, old, new):
+    def on_change(self, *, old, new):
         pass
 
     def update(self, readings):
@@ -45,7 +45,7 @@ class Tracker(HasLogger, HasStore):
 
         self.logger.debug(f"Storing tracked values: {new_values}")
         self.store[f"{self.__id}-tracked-values"] = new_values
-        self.on_change(values, new_values)
+        self.on_change(old=values, new=new_values)
 
     def __filter_value(self, readings, name):
         for reading in readings:

--- a/src/snsary/utils/tracker.py
+++ b/src/snsary/utils/tracker.py
@@ -17,7 +17,7 @@ class Tracker(HasLogger, HasStore):
 
     @property
     def values(self):
-        return self.store.get(f'{self.__id}-tracked-values', {})
+        return self.store.get(f"{self.__id}-tracked-values", {})
 
     def on_change(self, old, new):
         pass
@@ -30,21 +30,21 @@ class Tracker(HasLogger, HasStore):
             current_value = self.__filter_value(readings, name)
 
             if not current_value:
-                self.logger.debug(f'Tracker missing value for {name}.')
+                self.logger.debug(f"Tracker missing value for {name}.")
                 return
 
             if name not in values:
-                self.logger.debug(f'Tracker filling value for {name}.')
+                self.logger.debug(f"Tracker filling value for {name}.")
                 new_values[name] = current_value
             else:
                 new_values[name] = fn(current_value, values[name])
 
         if new_values == values:
-            self.logger.debug('Tracked values unchanged, continuing.')
+            self.logger.debug("Tracked values unchanged, continuing.")
             return
 
-        self.logger.debug(f'Storing tracked values: {new_values}')
-        self.store[f'{self.__id}-tracked-values'] = new_values
+        self.logger.debug(f"Storing tracked values: {new_values}")
+        self.store[f"{self.__id}-tracked-values"] = new_values
         self.on_change(values, new_values)
 
     def __filter_value(self, readings, name):
@@ -57,9 +57,7 @@ class MaxTracker(Tracker):
     def __init__(self, id, *, names, on_change):
         self.on_change = on_change
 
-        Tracker.__init__(
-            self, id, **{name: max for name in names}
-        )
+        Tracker.__init__(self, id, **{name: max for name in names})
 
 
 class NullTracker(Tracker):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,4 +39,9 @@ def create_reading(
     value=123,
     name="myreading"
 ):
-    return Reading(sensor_name=sensor_name, timestamp=timestamp, value=value, name=name)
+    return Reading(
+        sensor_name=sensor_name,
+        timestamp=timestamp,
+        value=value,
+        name=name,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,21 +27,16 @@ def sensor():
     class FakeSensor(Sensor):
         @property
         def name(self):
-            return 'mysensor'
+            return "mysensor"
 
     return FakeSensor()
 
 
 def create_reading(
     *,
-    sensor_name='mysensor',
+    sensor_name="mysensor",
     timestamp=1650745546,  # 2022-04-23T21:25:46+01:00
     value=123,
-    name='myreading'
+    name="myreading"
 ):
-    return Reading(
-        sensor_name=sensor_name,
-        timestamp=timestamp,
-        value=value,
-        name=name
-    )
+    return Reading(sensor_name=sensor_name, timestamp=timestamp, value=value, name=name)

--- a/tests/contrib/adafruit/test_generic.py
+++ b/tests/contrib/adafruit/test_generic.py
@@ -19,19 +19,17 @@ def sensor(mock_device):
 
 
 def test_name(sensor):
-    assert sensor.name == 'MockDevice'
+    assert sensor.name == "MockDevice"
 
 
 def test_sample(sensor, mock_device):
-    readings = list(sensor.sample(
-        timestamp='now'
-    ))
+    readings = list(sensor.sample(timestamp="now"))
 
     assert len(readings) == 1
-    assert readings[0].name == 'data'
+    assert readings[0].name == "data"
     assert readings[0].value == 1.23
-    assert readings[0].sensor_name == 'MockDevice'
-    assert readings[0].timestamp == 'now'
+    assert readings[0].sensor_name == "MockDevice"
+    assert readings[0].timestamp == "now"
 
 
 def test_sample_not_ready(sensor):

--- a/tests/contrib/adafruit/test_sgp30.py
+++ b/tests/contrib/adafruit/test_sgp30.py
@@ -7,7 +7,10 @@ from tests.conftest import create_reading
 
 @pytest.fixture
 def mock_sgp30(mocker):
-    mock_class = mocker.patch("adafruit_sgp30.Adafruit_SGP30", autospec=True)
+    mock_class = mocker.patch(
+        "adafruit_sgp30.Adafruit_SGP30",
+        autospec=True,
+    )
 
     return mock_class("i2c")
 
@@ -43,12 +46,23 @@ def test_start(
     mock_sgp30.set_iaq_baseline.assert_not_called()
 
 
-def test_start_restore(sensor, mock_sgp30, mock_generic, mock_store):
-    mock_store["SGP30-tracked-values"] = {"baseline_TVOC": 123, "baseline_eCO2": 456}
+def test_start_restore(
+    sensor,
+    mock_sgp30,
+    mock_generic,
+    mock_store,
+):
+    mock_store["SGP30-tracked-values"] = {
+        "baseline_TVOC": 123,
+        "baseline_eCO2": 456,
+    }
 
     sensor.start()
 
-    mock_sgp30.set_iaq_baseline.assert_called_with(TVOC=123, eCO2=456)
+    mock_sgp30.set_iaq_baseline.assert_called_with(
+        TVOC=123,
+        eCO2=456,
+    )
 
 
 def test_ready(sensor):
@@ -91,6 +105,12 @@ def test_sample(sensor, mock_generic, mocker):
 
 
 def test_tracked_values_changed(sensor, mock_sgp30):
-    sensor.tracker.on_change(None, {"baseline_TVOC": "tvoc", "baseline_eCO2": "eco2"})
+    sensor.tracker.on_change(
+        None,
+        {"baseline_TVOC": "tvoc", "baseline_eCO2": "eco2"},
+    )
 
-    mock_sgp30.set_iaq_baseline.assert_called_with(TVOC="tvoc", eCO2="eco2")
+    mock_sgp30.set_iaq_baseline.assert_called_with(
+        TVOC="tvoc",
+        eCO2="eco2",
+    )

--- a/tests/contrib/adafruit/test_sgp30.py
+++ b/tests/contrib/adafruit/test_sgp30.py
@@ -104,10 +104,10 @@ def test_sample(sensor, mock_generic, mocker):
     mock_tracker.update.assert_called_with(["readings"])
 
 
-def test_tracked_values_changed(sensor, mock_sgp30):
+def test_baselines_changed(sensor, mock_sgp30):
     sensor.tracker.on_change(
-        None,
-        {"baseline_TVOC": "tvoc", "baseline_eCO2": "eco2"},
+        old=None,
+        new={"baseline_TVOC": "tvoc", "baseline_eCO2": "eco2"},
     )
 
     mock_sgp30.set_iaq_baseline.assert_called_with(

--- a/tests/contrib/adafruit/test_sgp30.py
+++ b/tests/contrib/adafruit/test_sgp30.py
@@ -7,17 +7,15 @@ from tests.conftest import create_reading
 
 @pytest.fixture
 def mock_sgp30(mocker):
-    mock_class = mocker.patch(
-        'adafruit_sgp30.Adafruit_SGP30', autospec=True
-    )
+    mock_class = mocker.patch("adafruit_sgp30.Adafruit_SGP30", autospec=True)
 
-    return mock_class('i2c')
+    return mock_class("i2c")
 
 
 @pytest.fixture
 def mock_generic(mocker):
     return mocker.patch(
-        'snsary.contrib.adafruit.sgp30.GenericSensor',
+        "snsary.contrib.adafruit.sgp30.GenericSensor",
     )
 
 
@@ -45,21 +43,12 @@ def test_start(
     mock_sgp30.set_iaq_baseline.assert_not_called()
 
 
-def test_start_restore(
-    sensor,
-    mock_sgp30,
-    mock_generic,
-    mock_store
-):
-    mock_store['SGP30-tracked-values'] = {
-        'baseline_TVOC': 123, 'baseline_eCO2': 456
-    }
+def test_start_restore(sensor, mock_sgp30, mock_generic, mock_store):
+    mock_store["SGP30-tracked-values"] = {"baseline_TVOC": 123, "baseline_eCO2": 456}
 
     sensor.start()
 
-    mock_sgp30.set_iaq_baseline.assert_called_with(
-        TVOC=123, eCO2=456
-    )
+    mock_sgp30.set_iaq_baseline.assert_called_with(TVOC=123, eCO2=456)
 
 
 def test_ready(sensor):
@@ -68,39 +57,40 @@ def test_ready(sensor):
 
 
 def test_publish_batch(sensor, mock_sgp30):
-    sensor.publish_batch([
-        create_reading(name='temperature', value=1),
-        create_reading(name='relative_humidity', value=2)
-    ])
+    sensor.publish_batch(
+        [
+            create_reading(name="temperature", value=1),
+            create_reading(name="relative_humidity", value=2),
+        ]
+    )
 
     mock_sgp30.set_iaq_relative_humidity.assert_called_with(
         celsius=1, relative_humidity=2
     )
 
 
-@pytest.mark.parametrize('readings', [
-    [create_reading(name='temperature')],
-    [create_reading(name='relative_humidity')],
-    []
-])
+@pytest.mark.parametrize(
+    "readings",
+    [
+        [create_reading(name="temperature")],
+        [create_reading(name="relative_humidity")],
+        [],
+    ],
+)
 def test_publish_batch_incomplete(sensor, mock_sgp30, readings):
     sensor.publish_batch(readings)
     mock_sgp30.set_iaq_humidity.assert_not_called()
 
 
 def test_sample(sensor, mock_generic, mocker):
-    mock_generic.sample.return_value = ['readings']
-    mock_tracker = mocker.patch.object(sensor, 'tracker')
+    mock_generic.sample.return_value = ["readings"]
+    mock_tracker = mocker.patch.object(sensor, "tracker")
 
-    assert sensor.sample() == ['readings']
-    mock_tracker.update.assert_called_with(['readings'])
+    assert sensor.sample() == ["readings"]
+    mock_tracker.update.assert_called_with(["readings"])
 
 
 def test_tracked_values_changed(sensor, mock_sgp30):
-    sensor.tracker.on_change(
-        None, {'baseline_TVOC': 'tvoc', 'baseline_eCO2': 'eco2'}
-    )
+    sensor.tracker.on_change(None, {"baseline_TVOC": "tvoc", "baseline_eCO2": "eco2"})
 
-    mock_sgp30.set_iaq_baseline.assert_called_with(
-        TVOC='tvoc', eCO2='eco2'
-    )
+    mock_sgp30.set_iaq_baseline.assert_called_with(TVOC="tvoc", eCO2="eco2")

--- a/tests/contrib/datastax/test_datastax.py
+++ b/tests/contrib/datastax/test_datastax.py
@@ -23,7 +23,10 @@ def schema():
 @httpretty.activate(allow_net_connect=False)
 def graphql(schema):
     httpretty.register_uri(
-        httpretty.POST, "http://graphql/", content_type="application/json", body=schema
+        httpretty.POST,
+        "http://graphql/",
+        content_type="application/json",
+        body=schema,
     )
 
     return GraphQLOutput(url="http://graphql", token="token")
@@ -43,12 +46,15 @@ def test_from_env(mocker):
     )
 
     assert isinstance(GraphQLOutput.from_env(), GraphQLOutput)
-
     mock_init.assert_called_with(url="url", token="token")
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch(mocker, graphql, reading):
+def test_publish_batch(
+    mocker,
+    graphql,
+    reading,
+):
     httpretty.register_uri(
         httpretty.POST,
         "http://graphql/",
@@ -78,9 +84,16 @@ def test_publish_batch(mocker, graphql, reading):
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch_error(graphql, sensor, reading):
+def test_publish_batch_error(
+    graphql,
+    sensor,
+    reading,
+):
     httpretty.register_uri(
-        httpretty.POST, "http://graphql/", content_type="application/json", status=500
+        httpretty.POST,
+        "http://graphql/",
+        content_type="application/json",
+        status=500,
     )
 
     with pytest.raises(Exception) as excinfo:

--- a/tests/contrib/datastax/test_datastax.py
+++ b/tests/contrib/datastax/test_datastax.py
@@ -16,92 +16,74 @@ from snsary.contrib.datastax import GraphQLOutput
 @pytest.fixture()
 def schema():
     file = f"{Path(__file__).parent}/schema.json"
-    return open(file, 'r').read()
+    return open(file, "r").read()
 
 
 @pytest.fixture
 @httpretty.activate(allow_net_connect=False)
 def graphql(schema):
     httpretty.register_uri(
-        httpretty.POST,
-        'http://graphql/',
-        content_type='application/json',
-        body=schema
+        httpretty.POST, "http://graphql/", content_type="application/json", body=schema
     )
 
-    return GraphQLOutput(
-        url="http://graphql", token="token"
-    )
+    return GraphQLOutput(url="http://graphql", token="token")
 
 
 def test_from_env(mocker):
-    mocker.patch.dict(os.environ, {
-        'DATASTAX_URL': 'url',
-        'DATASTAX_TOKEN': 'token',
-    })
+    mocker.patch.dict(
+        os.environ,
+        {
+            "DATASTAX_URL": "url",
+            "DATASTAX_TOKEN": "token",
+        },
+    )
 
     mock_init = mocker.patch.object(
-        GraphQLOutput, '__init__',
-        return_value=None  # required to mock __init__
+        GraphQLOutput, "__init__", return_value=None  # required to mock __init__
     )
 
-    assert isinstance(
-        GraphQLOutput.from_env(), GraphQLOutput
-    )
+    assert isinstance(GraphQLOutput.from_env(), GraphQLOutput)
 
-    mock_init.assert_called_with(
-        url='url', token='token'
-    )
+    mock_init.assert_called_with(url="url", token="token")
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch(
-    mocker,
-    graphql,
-    reading
-):
+def test_publish_batch(mocker, graphql, reading):
     httpretty.register_uri(
         httpretty.POST,
-        'http://graphql/',
-        content_type='application/json',
-        body='{"data": []}'
+        "http://graphql/",
+        content_type="application/json",
+        body='{"data": []}',
     )
 
-    mocker.patch('platform.node', return_value='snsary')
+    mocker.patch("platform.node", return_value="snsary")
     graphql.publish_batch([reading])
     request = httpretty.last_request()
 
     # extracted using the following in a debugger session
     # pprint(json.loads(str(request.body, 'utf-8')))
     assert json.loads(request.body) == {
-        'query': 'mutation {\n'
-        '  r0: insertreading(\n'
-        '    options: {ttl: 33696000}\n'
+        "query": "mutation {\n"
+        "  r0: insertreading(\n"
+        "    options: {ttl: 33696000}\n"
         '    value: {host: "snsary", sensor: "mysensor", metric: '
         '"myreading", timestamp: "2022-04-23T20:25:46+00:00", value: 123}\n'
-        '  ) {\n'
-        '    value {\n'
-        '      metric\n'
-        '    }\n'
-        '  }\n'
-        '}'
+        "  ) {\n"
+        "    value {\n"
+        "      metric\n"
+        "    }\n"
+        "  }\n"
+        "}"
     }
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch_error(
-    graphql,
-    sensor,
-    reading
-):
+def test_publish_batch_error(graphql, sensor, reading):
     httpretty.register_uri(
-        httpretty.POST,
-        'http://graphql/',
-        content_type='application/json',
-        status=500
+        httpretty.POST, "http://graphql/", content_type="application/json", status=500
     )
 
     with pytest.raises(Exception) as excinfo:
         graphql.publish_batch([reading])
 
-    assert 'Internal Server Error' in str(excinfo.value)
+    assert "Internal Server Error" in str(excinfo.value)

--- a/tests/contrib/google/test_bigquery.py
+++ b/tests/contrib/google/test_bigquery.py
@@ -4,7 +4,7 @@ import pytest
 
 from snsary.contrib.google import BigQueryOutput, reading_pb2
 
-STREAM_NAME = 'projects/test-project/datasets/snsary/tables/readings/streams/_default'
+STREAM_NAME = "projects/test-project/datasets/snsary/tables/readings/streams/_default"
 
 
 @pytest.fixture
@@ -12,7 +12,7 @@ def mock_client(mocker):
     # Integration testing with HTTP stubs isn't possible here, as the BigQuery Storage
     # package uses Cython bindings instead of use Python's native transport libraries,
     # which is what HTTP mocking libraries intercept.
-    return mocker.patch('google.cloud.bigquery_storage_v1.BigQueryWriteClient')()
+    return mocker.patch("google.cloud.bigquery_storage_v1.BigQueryWriteClient")()
 
 
 @pytest.fixture
@@ -21,20 +21,20 @@ def big_query(mock_client):
 
 
 def test_from_env(mocker):
-    mocker.patch.dict(os.environ, {
-        'GOOGLE_BIGQUERY_STREAM': 'stream',
-    })
+    mocker.patch.dict(
+        os.environ,
+        {
+            "GOOGLE_BIGQUERY_STREAM": "stream",
+        },
+    )
 
     mock_init = mocker.patch.object(
-        BigQueryOutput, '__init__',
-        return_value=None  # required to mock __init__
+        BigQueryOutput, "__init__", return_value=None  # required to mock __init__
     )
 
-    assert isinstance(
-        BigQueryOutput.from_env(), BigQueryOutput
-    )
+    assert isinstance(BigQueryOutput.from_env(), BigQueryOutput)
 
-    mock_init.assert_called_with(stream='stream')
+    mock_init.assert_called_with(stream="stream")
 
 
 def test_publish_batch(
@@ -43,28 +43,28 @@ def test_publish_batch(
     big_query,
     mock_client,
 ):
-    mocker.patch('platform.node', return_value='snsary')
+    mocker.patch("platform.node", return_value="snsary")
 
     big_query.publish_batch([reading])
     assert mock_client.append_rows.called
 
     last_call = mock_client.append_rows.mock_calls[0]
-    assert last_call.kwargs['retry'].deadline == big_query.RETRY_DEADLINE
+    assert last_call.kwargs["retry"].deadline == big_query.RETRY_DEADLINE
 
-    request = next(last_call.kwargs['requests'])
+    request = next(last_call.kwargs["requests"])
     assert request.write_stream == STREAM_NAME
 
     proto_rows = request.proto_rows
-    assert proto_rows.writer_schema.proto_descriptor.name == 'Reading'
+    assert proto_rows.writer_schema.proto_descriptor.name == "Reading"
 
     serialized_rows = proto_rows.rows.serialized_rows
     assert len(serialized_rows) == 1
 
     proto_reading = reading_pb2.Reading.FromString(serialized_rows[0])
-    assert proto_reading.host == 'snsary'
-    assert proto_reading.sensor == 'mysensor'
-    assert proto_reading.metric == 'myreading'
-    assert proto_reading.timestamp == '2022-04-23T20:25:46+00:00'
+    assert proto_reading.host == "snsary"
+    assert proto_reading.sensor == "mysensor"
+    assert proto_reading.metric == "myreading"
+    assert proto_reading.timestamp == "2022-04-23T20:25:46+00:00"
     assert proto_reading.value == 123
 
 

--- a/tests/contrib/google/test_bigquery.py
+++ b/tests/contrib/google/test_bigquery.py
@@ -33,7 +33,6 @@ def test_from_env(mocker):
     )
 
     assert isinstance(BigQueryOutput.from_env(), BigQueryOutput)
-
     mock_init.assert_called_with(stream="stream")
 
 

--- a/tests/contrib/test_awair.py
+++ b/tests/contrib/test_awair.py
@@ -12,24 +12,18 @@ from snsary.contrib.awair import AwairSensor
 
 @pytest.fixture
 def sensor():
-    return AwairSensor(
-        device_type='awair-r2',
-        device_id='1234',
-        token='token-123'
-    )
+    return AwairSensor(device_type="awair-r2", device_id="1234", token="token-123")
 
 
 def test_discover_from_env(mocker):
-    mocker.patch.dict(os.environ, {
-        'AWAIR_TOKEN': 'token'
-    })
+    mocker.patch.dict(os.environ, {"AWAIR_TOKEN": "token"})
 
     mock_discover = mocker.patch.object(
-        AwairSensor, 'discover', return_value='instances'
+        AwairSensor, "discover", return_value="instances"
     )
 
-    assert AwairSensor.discover_from_env() == 'instances'
-    mock_discover.assert_called_with(token='token')
+    assert AwairSensor.discover_from_env() == "instances"
+    mock_discover.assert_called_with(token="token")
 
 
 @httpretty.activate(allow_net_connect=False)
@@ -37,20 +31,15 @@ def test_discover():
     httpretty.register_uri(
         httpretty.GET,
         AwairSensor.DEVICES_URL,
-        body=json.dumps({
-            'devices': [{
-                'deviceType': 'awair-r2',
-                'deviceId': '1234'
-            }]
-        })
+        body=json.dumps({"devices": [{"deviceType": "awair-r2", "deviceId": "1234"}]}),
     )
 
-    sensors = AwairSensor.discover(token='token-123')
+    sensors = AwairSensor.discover(token="token-123")
     assert len(sensors) == 1
-    assert sensors[0].name == 'awair-r2-1234'
+    assert sensors[0].name == "awair-r2-1234"
 
     request = httpretty.last_request()
-    assert request.headers['Authorization'] == 'Bearer token-123'
+    assert request.headers["Authorization"] == "Bearer token-123"
 
 
 @httpretty.activate(allow_net_connect=False)
@@ -62,50 +51,48 @@ def test_discover_error():
     )
 
     with pytest.raises(Exception) as excinfo:
-        AwairSensor.discover(token='token-123')
+        AwairSensor.discover(token="token-123")
 
-    assert '500 Server Error' in str(excinfo.value)
+    assert "500 Server Error" in str(excinfo.value)
 
 
 @time_machine.travel("2022-04-05T12:00:00+01:00", tick=False)
 @httpretty.activate(allow_net_connect=False)
-def test_sample(
-    sensor
-):
-    url = AwairSensor.DATA_URL.format(**{
-        'deviceType': 'awair-r2',
-        'deviceId': '1234',
-        'from': '2022-04-05T10:50:00Z'
-    })
+def test_sample(sensor):
+    url = AwairSensor.DATA_URL.format(
+        **{"deviceType": "awair-r2", "deviceId": "1234", "from": "2022-04-05T10:50:00Z"}
+    )
 
     httpretty.register_uri(
         httpretty.GET,
         url,
         match_querystring=True,
-        body=json.dumps({
-            'data': [{
-                'timestamp': '2022-04-05T10:55:00.000Z',
-                'sensors': [{'comp': 'temp', 'value': 123}]
-            }]
-        })
+        body=json.dumps(
+            {
+                "data": [
+                    {
+                        "timestamp": "2022-04-05T10:55:00.000Z",
+                        "sensors": [{"comp": "temp", "value": 123}],
+                    }
+                ]
+            }
+        ),
     )
 
     readings = sensor.sample(now=datetime.now().astimezone())
     assert len(readings) == 1
 
     assert readings[0].value == 123
-    assert readings[0].sensor_name == 'awair-r2-1234'
-    assert readings[0].name == 'temp'
+    assert readings[0].sensor_name == "awair-r2-1234"
+    assert readings[0].name == "temp"
     assert datetime.fromtimestamp(readings[0].timestamp).minute == 55
 
     request = httpretty.last_request()
-    assert request.headers['Authorization'] == 'Bearer token-123'
+    assert request.headers["Authorization"] == "Bearer token-123"
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_sample_error(
-    sensor
-):
+def test_sample_error(sensor):
     httpretty.register_uri(
         httpretty.GET,
         re.compile(".*"),
@@ -115,4 +102,4 @@ def test_sample_error(
     with pytest.raises(Exception) as excinfo:
         sensor.sample(now=datetime.now().astimezone())
 
-    assert '500 Server Error' in str(excinfo.value)
+    assert "500 Server Error" in str(excinfo.value)

--- a/tests/contrib/test_awair.py
+++ b/tests/contrib/test_awair.py
@@ -99,7 +99,8 @@ def test_sample(sensor):
         ),
     )
 
-    readings = sensor.sample(now=datetime.now().astimezone())
+    now = datetime.now().astimezone()
+    readings = list(sensor.sample(now=now))
     assert len(readings) == 1
 
     assert readings[0].value == 123
@@ -122,6 +123,7 @@ def test_sample_error(
     )
 
     with pytest.raises(Exception) as excinfo:
-        sensor.sample(now=datetime.now().astimezone())
+        now = datetime.now().astimezone()
+        list(sensor.sample(now=now))
 
     assert "500 Server Error" in str(excinfo.value)

--- a/tests/contrib/test_awair.py
+++ b/tests/contrib/test_awair.py
@@ -12,11 +12,18 @@ from snsary.contrib.awair import AwairSensor
 
 @pytest.fixture
 def sensor():
-    return AwairSensor(device_type="awair-r2", device_id="1234", token="token-123")
+    return AwairSensor(
+        device_type="awair-r2",
+        device_id="1234",
+        token="token-123",
+    )
 
 
 def test_discover_from_env(mocker):
-    mocker.patch.dict(os.environ, {"AWAIR_TOKEN": "token"})
+    mocker.patch.dict(
+        os.environ,
+        {"AWAIR_TOKEN": "token"},
+    )
 
     mock_discover = mocker.patch.object(
         AwairSensor, "discover", return_value="instances"
@@ -31,7 +38,16 @@ def test_discover():
     httpretty.register_uri(
         httpretty.GET,
         AwairSensor.DEVICES_URL,
-        body=json.dumps({"devices": [{"deviceType": "awair-r2", "deviceId": "1234"}]}),
+        body=json.dumps(
+            {
+                "devices": [
+                    {
+                        "deviceType": "awair-r2",
+                        "deviceId": "1234",
+                    }
+                ]
+            }
+        ),
     )
 
     sensors = AwairSensor.discover(token="token-123")
@@ -60,7 +76,11 @@ def test_discover_error():
 @httpretty.activate(allow_net_connect=False)
 def test_sample(sensor):
     url = AwairSensor.DATA_URL.format(
-        **{"deviceType": "awair-r2", "deviceId": "1234", "from": "2022-04-05T10:50:00Z"}
+        **{
+            "deviceType": "awair-r2",
+            "deviceId": "1234",
+            "from": "2022-04-05T10:50:00Z",
+        }
     )
 
     httpretty.register_uri(
@@ -92,7 +112,9 @@ def test_sample(sensor):
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_sample_error(sensor):
+def test_sample_error(
+    sensor,
+):
     httpretty.register_uri(
         httpretty.GET,
         re.compile(".*"),

--- a/tests/contrib/test_grafana.py
+++ b/tests/contrib/test_grafana.py
@@ -9,7 +9,10 @@ from snsary.contrib.grafana import GraphiteOutput
 
 @pytest.fixture()
 def graphite():
-    return GraphiteOutput(url="http://graphite", prefix="snsary")
+    return GraphiteOutput(
+        url="http://graphite",
+        prefix="snsary",
+    )
 
 
 def test_from_env(mocker):
@@ -25,8 +28,15 @@ def test_from_env(mocker):
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch(graphite, sensor, reading):
-    httpretty.register_uri(httpretty.POST, "http://graphite/")
+def test_publish_batch(
+    graphite,
+    sensor,
+    reading,
+):
+    httpretty.register_uri(
+        httpretty.POST,
+        "http://graphite/",
+    )
 
     graphite.publish_batch([reading])
     request = httpretty.last_request()
@@ -42,8 +52,16 @@ def test_publish_batch(graphite, sensor, reading):
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch_error(graphite, sensor, reading):
-    httpretty.register_uri(httpretty.POST, "http://graphite/", status=500)
+def test_publish_batch_error(
+    graphite,
+    sensor,
+    reading,
+):
+    httpretty.register_uri(
+        httpretty.POST,
+        "http://graphite/",
+        status=500,
+    )
 
     with pytest.raises(Exception) as excinfo:
         graphite.publish_batch([reading])

--- a/tests/contrib/test_grafana.py
+++ b/tests/contrib/test_grafana.py
@@ -9,59 +9,43 @@ from snsary.contrib.grafana import GraphiteOutput
 
 @pytest.fixture()
 def graphite():
-    return GraphiteOutput(
-        url='http://graphite', prefix='snsary'
-    )
+    return GraphiteOutput(url="http://graphite", prefix="snsary")
 
 
 def test_from_env(mocker):
-    mocker.patch.dict(os.environ, {'GRAPHITE_URL': 'url'})
-    mocker.patch('platform.node', return_value='snsary')
+    mocker.patch.dict(os.environ, {"GRAPHITE_URL": "url"})
+    mocker.patch("platform.node", return_value="snsary")
 
     mock_init = mocker.patch.object(
-        GraphiteOutput, '__init__',
-        return_value=None  # required to mock __init__
+        GraphiteOutput, "__init__", return_value=None  # required to mock __init__
     )
 
     assert isinstance(GraphiteOutput.from_env(), GraphiteOutput)
-    mock_init.assert_called_with(url='url', prefix='snsary')
+    mock_init.assert_called_with(url="url", prefix="snsary")
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch(
-    graphite,
-    sensor,
-    reading
-):
-    httpretty.register_uri(
-        httpretty.POST,
-        'http://graphite/'
-    )
+def test_publish_batch(graphite, sensor, reading):
+    httpretty.register_uri(httpretty.POST, "http://graphite/")
 
     graphite.publish_batch([reading])
     request = httpretty.last_request()
 
-    assert json.loads(request.body) == [{
-        'interval': 1,
-        'name': 'snsary.mysensor.myreading',
-        'time': 1650745546,
-        'value': 123
-    }]
+    assert json.loads(request.body) == [
+        {
+            "interval": 1,
+            "name": "snsary.mysensor.myreading",
+            "time": 1650745546,
+            "value": 123,
+        }
+    ]
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch_error(
-    graphite,
-    sensor,
-    reading
-):
-    httpretty.register_uri(
-        httpretty.POST,
-        'http://graphite/',
-        status=500
-    )
+def test_publish_batch_error(graphite, sensor, reading):
+    httpretty.register_uri(httpretty.POST, "http://graphite/", status=500)
 
     with pytest.raises(Exception) as excinfo:
         graphite.publish_batch([reading])
 
-    assert '500 Server Error' in str(excinfo.value)
+    assert "500 Server Error" in str(excinfo.value)

--- a/tests/contrib/test_influxdb.py
+++ b/tests/contrib/test_influxdb.py
@@ -9,7 +9,10 @@ from snsary.contrib.influxdb import InfluxDBOutput
 @pytest.fixture()
 def influxdb():
     return InfluxDBOutput(
-        url="http://influxdb", token="token", org="org", bucket="bucket"
+        url="http://influxdb",
+        token="token",
+        org="org",
+        bucket="bucket",
     )
 
 
@@ -30,13 +33,24 @@ def test_from_env(mocker):
 
     assert isinstance(InfluxDBOutput.from_env(), InfluxDBOutput)
 
-    mock_init.assert_called_with(url="url", token="token", org="org", bucket="bucket")
+    mock_init.assert_called_with(
+        url="url",
+        token="token",
+        org="org",
+        bucket="bucket",
+    )
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch(mocker, influxdb, sensor, reading):
+def test_publish_batch(
+    mocker,
+    influxdb,
+    sensor,
+    reading,
+):
     httpretty.register_uri(
-        httpretty.POST, "http://influxdb/api/v2/write?org=org&bucket=bucket&precision=s"
+        httpretty.POST,
+        "http://influxdb/api/v2/write?org=org&bucket=bucket&precision=s",
     )
 
     mocker.patch("platform.node", return_value="snsary")
@@ -50,7 +64,11 @@ def test_publish_batch(mocker, influxdb, sensor, reading):
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch_error(influxdb, sensor, reading):
+def test_publish_batch_error(
+    influxdb,
+    sensor,
+    reading,
+):
     httpretty.register_uri(
         httpretty.POST,
         "http://influxdb/api/v2/write?org=org&bucket=bucket&precision=s",

--- a/tests/contrib/test_influxdb.py
+++ b/tests/contrib/test_influxdb.py
@@ -9,71 +9,55 @@ from snsary.contrib.influxdb import InfluxDBOutput
 @pytest.fixture()
 def influxdb():
     return InfluxDBOutput(
-        url='http://influxdb',
-        token='token',
-        org='org',
-        bucket='bucket'
+        url="http://influxdb", token="token", org="org", bucket="bucket"
     )
 
 
 def test_from_env(mocker):
-    mocker.patch.dict(os.environ, {
-        'INFLUXDB_URL': 'url',
-        'INFLUXDB_TOKEN': 'token',
-        'INFLUXDB_ORG': 'org',
-        'INFLUXDB_BUCKET': 'bucket'
-    })
+    mocker.patch.dict(
+        os.environ,
+        {
+            "INFLUXDB_URL": "url",
+            "INFLUXDB_TOKEN": "token",
+            "INFLUXDB_ORG": "org",
+            "INFLUXDB_BUCKET": "bucket",
+        },
+    )
 
     mock_init = mocker.patch.object(
-        InfluxDBOutput, '__init__',
-        return_value=None  # required to mock __init__
+        InfluxDBOutput, "__init__", return_value=None  # required to mock __init__
     )
 
-    assert isinstance(
-        InfluxDBOutput.from_env(), InfluxDBOutput
-    )
+    assert isinstance(InfluxDBOutput.from_env(), InfluxDBOutput)
 
-    mock_init.assert_called_with(
-        url='url',
-        token='token',
-        org='org',
-        bucket='bucket'
-    )
+    mock_init.assert_called_with(url="url", token="token", org="org", bucket="bucket")
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch(
-    mocker,
-    influxdb,
-    sensor,
-    reading
-):
+def test_publish_batch(mocker, influxdb, sensor, reading):
     httpretty.register_uri(
-        httpretty.POST,
-        'http://influxdb/api/v2/write?org=org&bucket=bucket&precision=s'
+        httpretty.POST, "http://influxdb/api/v2/write?org=org&bucket=bucket&precision=s"
     )
 
-    mocker.patch('platform.node', return_value='snsary')
+    mocker.patch("platform.node", return_value="snsary")
     influxdb.publish_batch([reading])
     request = httpretty.last_request()
 
-    assert request.headers['Authorization'] == 'Token token'
-    assert b'myreading,host=snsary,sensor=mysensor value=123i 1650745546' in request.body
+    assert request.headers["Authorization"] == "Token token"
+    assert (
+        b"myreading,host=snsary,sensor=mysensor value=123i 1650745546" in request.body
+    )
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_publish_batch_error(
-    influxdb,
-    sensor,
-    reading
-):
+def test_publish_batch_error(influxdb, sensor, reading):
     httpretty.register_uri(
         httpretty.POST,
-        'http://influxdb/api/v2/write?org=org&bucket=bucket&precision=s',
-        status=500
+        "http://influxdb/api/v2/write?org=org&bucket=bucket&precision=s",
+        status=500,
     )
 
     with pytest.raises(Exception) as excinfo:
         influxdb.publish_batch([reading])
 
-    assert 'Internal Server Error' in str(excinfo.value)
+    assert "Internal Server Error" in str(excinfo.value)

--- a/tests/contrib/test_octopus.py
+++ b/tests/contrib/test_octopus.py
@@ -14,13 +14,21 @@ from snsary.contrib.octopus import OctopusSensor
 
 @pytest.fixture
 def sensor():
-    return OctopusSensor(mpan="mpan", serial_number="serial_number", token="token-123")
+    return OctopusSensor(
+        mpan="mpan",
+        serial_number="serial_number",
+        token="token-123",
+    )
 
 
 def test_from_env(mocker):
     mocker.patch.dict(
         os.environ,
-        {"OCTOPUS_MPAN": "mpan", "OCTOPUS_SERIAL": "serial", "OCTOPUS_TOKEN": "token"},
+        {
+            "OCTOPUS_MPAN": "mpan",
+            "OCTOPUS_SERIAL": "serial",
+            "OCTOPUS_TOKEN": "token",
+        },
     )
 
     mock_init = mocker.patch.object(
@@ -29,7 +37,11 @@ def test_from_env(mocker):
 
     assert isinstance(OctopusSensor.from_env(), OctopusSensor)
 
-    mock_init.assert_called_with(mpan="mpan", serial_number="serial", token="token")
+    mock_init.assert_called_with(
+        mpan="mpan",
+        serial_number="serial",
+        token="token",
+    )
 
 
 @time_machine.travel(
@@ -38,7 +50,9 @@ def test_from_env(mocker):
     tick=False,
 )
 @httpretty.activate(allow_net_connect=False)
-def test_sample(sensor):
+def test_sample(
+    sensor,
+):
     url = OctopusSensor.CONSUMPTION_URL.format(
         **{
             "mpan": "mpan",
@@ -78,7 +92,9 @@ def test_sample(sensor):
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_sample_error(sensor):
+def test_sample_error(
+    sensor,
+):
     httpretty.register_uri(
         httpretty.GET,
         re.compile(".*"),

--- a/tests/contrib/test_octopus.py
+++ b/tests/contrib/test_octopus.py
@@ -14,81 +14,71 @@ from snsary.contrib.octopus import OctopusSensor
 
 @pytest.fixture
 def sensor():
-    return OctopusSensor(
-        mpan='mpan',
-        serial_number='serial_number',
-        token='token-123'
-    )
+    return OctopusSensor(mpan="mpan", serial_number="serial_number", token="token-123")
 
 
 def test_from_env(mocker):
-    mocker.patch.dict(os.environ, {
-        'OCTOPUS_MPAN': 'mpan',
-        'OCTOPUS_SERIAL': 'serial',
-        'OCTOPUS_TOKEN': 'token'
-    })
+    mocker.patch.dict(
+        os.environ,
+        {"OCTOPUS_MPAN": "mpan", "OCTOPUS_SERIAL": "serial", "OCTOPUS_TOKEN": "token"},
+    )
 
     mock_init = mocker.patch.object(
-        OctopusSensor, '__init__',
-        return_value=None  # required to mock __init__
+        OctopusSensor, "__init__", return_value=None  # required to mock __init__
     )
 
-    assert isinstance(
-        OctopusSensor.from_env(), OctopusSensor
-    )
+    assert isinstance(OctopusSensor.from_env(), OctopusSensor)
 
-    mock_init.assert_called_with(
-        mpan='mpan',
-        serial_number='serial',
-        token='token'
-    )
+    mock_init.assert_called_with(mpan="mpan", serial_number="serial", token="token")
 
 
 @time_machine.travel(
     # temporarily set timezone to Europe/London
-    datetime(2022, 4, 5, 15, 32, 23, tzinfo=ZoneInfo('Europe/London')),
-    tick=False
+    datetime(2022, 4, 5, 15, 32, 23, tzinfo=ZoneInfo("Europe/London")),
+    tick=False,
 )
 @httpretty.activate(allow_net_connect=False)
-def test_sample(
-    sensor
-):
-    url = OctopusSensor.CONSUMPTION_URL.format(**{
-        'mpan': 'mpan',
-        'serial_number': 'serial_number',
-        'period_from': '2022-04-03T23:00:00Z'
-    })
+def test_sample(sensor):
+    url = OctopusSensor.CONSUMPTION_URL.format(
+        **{
+            "mpan": "mpan",
+            "serial_number": "serial_number",
+            "period_from": "2022-04-03T23:00:00Z",
+        }
+    )
 
     httpretty.register_uri(
         httpretty.GET,
         url,
         match_querystring=True,
-        body=json.dumps({
-            'results': [{
-                "consumption": 0.076,
-                "interval_start": "2022-04-03T22:00:00Z",
-                "interval_end": "2022-04-03T22:30:00Z"
-            }]
-        })
+        body=json.dumps(
+            {
+                "results": [
+                    {
+                        "consumption": 0.076,
+                        "interval_start": "2022-04-03T22:00:00Z",
+                        "interval_end": "2022-04-03T22:30:00Z",
+                    }
+                ]
+            }
+        ),
     )
 
     readings = sensor.sample(now=datetime.now().astimezone())
     assert len(readings) == 1
 
     assert readings[0].value == 0.076
-    assert readings[0].sensor_name == 'octopus'
-    assert readings[0].name == 'consumption'
+    assert readings[0].sensor_name == "octopus"
+    assert readings[0].name == "consumption"
     assert datetime.fromtimestamp(readings[0].timestamp).minute == 30
 
     request = httpretty.last_request()
-    auth = base64.b64encode(b'token-123:').decode('utf-8')
-    assert request.headers['Authorization'] == f'Basic {auth}'
+    auth = base64.b64encode(b"token-123:").decode("utf-8")
+    assert request.headers["Authorization"] == f"Basic {auth}"
 
 
 @httpretty.activate(allow_net_connect=False)
-def test_sample_error(
-    sensor
-):
+def test_sample_error(sensor):
     httpretty.register_uri(
         httpretty.GET,
         re.compile(".*"),
@@ -98,4 +88,4 @@ def test_sample_error(
     with pytest.raises(Exception) as excinfo:
         sensor.sample(now=datetime.now().astimezone())
 
-    assert '500 Server Error' in str(excinfo.value)
+    assert "500 Server Error" in str(excinfo.value)

--- a/tests/contrib/test_octopus.py
+++ b/tests/contrib/test_octopus.py
@@ -78,7 +78,8 @@ def test_sample(
         ),
     )
 
-    readings = sensor.sample(now=datetime.now().astimezone())
+    now = datetime.now().astimezone()
+    readings = list(sensor.sample(now=now))
     assert len(readings) == 1
 
     assert readings[0].value == 0.076
@@ -102,6 +103,7 @@ def test_sample_error(
     )
 
     with pytest.raises(Exception) as excinfo:
-        sensor.sample(now=datetime.now().astimezone())
+        now = datetime.now().astimezone()
+        list(sensor.sample(now=now))
 
     assert "500 Server Error" in str(excinfo.value)

--- a/tests/contrib/test_pimoroni.py
+++ b/tests/contrib/test_pimoroni.py
@@ -4,39 +4,29 @@ from snsary.contrib.pimoroni import GenericSensor
 
 
 def test_mics6814_i2c(mocker):
-    mock_class = mocker.patch(
-        'mics6814.MICS6814', autospec=True
-    )
+    mock_class = mocker.patch("mics6814.MICS6814", autospec=True)
 
-    mock_class().read_all = lambda: Mics6814Reading(
-        ox=1, red=2, nh3=3, adc=4
-    )
+    mock_class().read_all = lambda: Mics6814Reading(ox=1, red=2, nh3=3, adc=4)
 
     sensor = GenericSensor.mics6814_i2c()
-    assert sensor.name == 'MICS6814'
+    assert sensor.name == "MICS6814"
     mock_class().set_led.assert_called_with(0, 0, 0)
 
-    readings = sorted(
-        sensor.sample(timestamp=1),
-        key=lambda reading: reading.name
-    )
+    readings = sorted(sensor.sample(timestamp=1), key=lambda reading: reading.name)
 
     assert len(readings) == 3
-    assert 'adc' not in {r.name for r in readings}
-    assert readings[0].name == 'nh3'
+    assert "adc" not in {r.name for r in readings}
+    assert readings[0].name == "nh3"
     assert readings[0].value == 3
 
 
 def test_sample():
-    sensor = GenericSensor(
-        name='sensor',
-        read_fn=lambda: [('name', 'value')]
-    )
+    sensor = GenericSensor(name="sensor", read_fn=lambda: [("name", "value")])
 
     readings = sensor.sample(timestamp=123)
 
     assert len(readings) == 1
-    assert readings[0].name == 'name'
-    assert readings[0].value == 'value'
-    assert readings[0].sensor_name == 'sensor'
+    assert readings[0].name == "name"
+    assert readings[0].value == "value"
+    assert readings[0].sensor_name == "sensor"
     assert readings[0].timestamp == 123

--- a/tests/contrib/test_pimoroni.py
+++ b/tests/contrib/test_pimoroni.py
@@ -4,15 +4,26 @@ from snsary.contrib.pimoroni import GenericSensor
 
 
 def test_mics6814_i2c(mocker):
-    mock_class = mocker.patch("mics6814.MICS6814", autospec=True)
+    mock_class = mocker.patch(
+        "mics6814.MICS6814",
+        autospec=True,
+    )
 
-    mock_class().read_all = lambda: Mics6814Reading(ox=1, red=2, nh3=3, adc=4)
+    mock_class().read_all = lambda: Mics6814Reading(
+        ox=1,
+        red=2,
+        nh3=3,
+        adc=4,
+    )
 
     sensor = GenericSensor.mics6814_i2c()
     assert sensor.name == "MICS6814"
     mock_class().set_led.assert_called_with(0, 0, 0)
 
-    readings = sorted(sensor.sample(timestamp=1), key=lambda reading: reading.name)
+    readings = sorted(
+        sensor.sample(timestamp=1),
+        key=lambda reading: reading.name,
+    )
 
     assert len(readings) == 3
     assert "adc" not in {r.name for r in readings}
@@ -21,7 +32,10 @@ def test_mics6814_i2c(mocker):
 
 
 def test_sample():
-    sensor = GenericSensor(name="sensor", read_fn=lambda: [("name", "value")])
+    sensor = GenericSensor(
+        name="sensor",
+        read_fn=lambda: [("name", "value")],
+    )
 
     readings = sensor.sample(timestamp=123)
 

--- a/tests/contrib/test_psutil.py
+++ b/tests/contrib/test_psutil.py
@@ -18,7 +18,9 @@ def test_sample(mocker):
         ],
     )
 
-    sensor = PSUtilSensor(functions={"disk_partitions": {}})
+    sensor = PSUtilSensor(
+        functions={"disk_partitions": {}},
+    )
 
     readings = sorted(sensor.sample(timestamp="now"), key=lambda r: r.name)
 

--- a/tests/contrib/test_psutil.py
+++ b/tests/contrib/test_psutil.py
@@ -5,36 +5,31 @@ from snsary.contrib.psutil import PSUtilSensor
 
 def test_sample(mocker):
     mocker.patch(
-        'snsary.contrib.psutil.psutil.disk_partitions',
+        "snsary.contrib.psutil.psutil.disk_partitions",
         return_value=[
             sdiskpart(
-                device='/dev/sda3',
-                mountpoint='/',
-                fstype='ext4',
-                opts='rw,errors=remount-ro',
+                device="/dev/sda3",
+                mountpoint="/",
+                fstype="ext4",
+                opts="rw,errors=remount-ro",
                 maxfile=255,
-                maxpath=4096
+                maxpath=4096,
             )
-        ]
+        ],
     )
 
-    sensor = PSUtilSensor(
-        functions={'disk_partitions': {}}
-    )
+    sensor = PSUtilSensor(functions={"disk_partitions": {}})
 
-    readings = sorted(
-        sensor.sample(timestamp='now'),
-        key=lambda r: r.name
-    )
+    readings = sorted(sensor.sample(timestamp="now"), key=lambda r: r.name)
 
     assert len(readings) == 2
-    assert readings[0].name == 'disk_partitions-0-maxfile'
+    assert readings[0].name == "disk_partitions-0-maxfile"
     assert readings[0].value == 255
-    assert readings[0].sensor_name == 'psutil'
-    assert readings[0].timestamp == 'now'
+    assert readings[0].sensor_name == "psutil"
+    assert readings[0].timestamp == "now"
 
 
 def test_sample_ignores_unavailable_stats(mocker):
-    sensor = PSUtilSensor(functions={'foo': {}})
-    readings = sensor.sample(timestamp='now')
+    sensor = PSUtilSensor(functions={"foo": {}})
+    readings = sensor.sample(timestamp="now")
     assert len(readings) == 0

--- a/tests/contrib/test_psutil.py
+++ b/tests/contrib/test_psutil.py
@@ -22,7 +22,12 @@ def test_sample(mocker):
         functions={"disk_partitions": {}},
     )
 
-    readings = sorted(sensor.sample(timestamp="now"), key=lambda r: r.name)
+    readings = list(
+        sorted(
+            sensor.sample(timestamp="now"),
+            key=lambda r: r.name,
+        )
+    )
 
     assert len(readings) == 2
     assert readings[0].name == "disk_partitions-0-maxfile"
@@ -33,5 +38,5 @@ def test_sample(mocker):
 
 def test_sample_ignores_unavailable_stats(mocker):
     sensor = PSUtilSensor(functions={"foo": {}})
-    readings = sensor.sample(timestamp="now")
+    readings = list(sensor.sample(timestamp="now"))
     assert len(readings) == 0

--- a/tests/contrib/test_pypms.py
+++ b/tests/contrib/test_pypms.py
@@ -10,9 +10,9 @@ def mock_sensor(mock_serial):
         name="wake",
         receive_bytes=b"BM\xe4\x00\x01\x01t",
         send_bytes=(
-            b"BM\x00\x1c"
-            + b".........................."  # expected header
-            + b"\x05W"  # payload (to total 32 bytes)  # checksum = sum(header) + sum(payload)
+            b"BM\x00\x1c"  # expected header
+            + b".........................."  # payload (to total 32 bytes)
+            + b"\x05W"  # checksum = sum(header) + sum(payload)
         ),
     )
 
@@ -20,9 +20,9 @@ def mock_sensor(mock_serial):
         name="passive_mode",
         receive_bytes=b"BM\xe1\x00\x00\x01p",
         send_bytes=(
-            b"BM\x00\x04"
-            + b".."  # expected header
-            + b"\x00\xef"  # payload (to total 8 bytes)  # checksum
+            b"BM\x00\x04"  # expected header
+            + b".."  # payload (to total 8 bytes)
+            + b"\x00\xef"  # checksum
         ),
     )
 
@@ -30,9 +30,9 @@ def mock_sensor(mock_serial):
         name="passive_read",
         receive_bytes=b"BM\xe2\x00\x00\x01q",
         send_bytes=(
-            b"BM\x00\x1c"
-            + b".........................."  # expected header
-            + b"\x05W"  # payload (to total 32 bytes)  # checksum
+            b"BM\x00\x1c"  # expected header
+            + b".........................."  # payload (to total 32 bytes)
+            + b"\x05W"  # checksum
         ),
     )
 
@@ -40,9 +40,9 @@ def mock_sensor(mock_serial):
         name="sleep",
         receive_bytes=b"BM\xe4\x00\x00\x01s",
         send_bytes=(
-            b"BM\x00\x04"
-            + b".."  # expected header
-            + b"\x00\xef"  # payload (to total 8 bytes)  # checksum
+            b"BM\x00\x04"  # expected header
+            + b".."  # payload (to total 8 bytes)
+            + b"\x00\xef"  # checksum
         ),
     )
 

--- a/tests/contrib/test_pypms.py
+++ b/tests/contrib/test_pypms.py
@@ -72,7 +72,11 @@ def test_init_sensor_not_found():
     assert "KeyError" in str(einfo)
 
 
-def test_start(mocker, mock_sensor, sensor):
+def test_start(
+    mocker,
+    mock_sensor,
+    sensor,
+):
     mock_start = mocker.patch("snsary.contrib.pypms.PollingSensor.start")
     sensor.start()
 
@@ -82,9 +86,15 @@ def test_start(mocker, mock_sensor, sensor):
 
 
 @pytest.mark.parametrize("send_bytes", [b"", b"123"])
-def test_start_bad_response(mock_sensor, sensor, send_bytes):
+def test_start_bad_response(
+    mock_sensor,
+    sensor,
+    send_bytes,
+):
     mock_sensor.stub(
-        name="passive_mode", receive_bytes=b"BM\xe1\x00\x00\x01p", send_bytes=send_bytes
+        name="passive_mode",
+        receive_bytes=b"BM\xe1\x00\x00\x01p",
+        send_bytes=send_bytes,
     )
 
     with pytest.raises(RuntimeError) as einfo:
@@ -111,7 +121,9 @@ def test_stop_bad_response(
     sensor,
 ):
     mock_sensor.stub(
-        name="sleep", receive_bytes=b"BM\xe4\x00\x00\x01s", send_bytes=b"123"
+        name="sleep",
+        receive_bytes=b"BM\xe4\x00\x00\x01s",
+        send_bytes=b"123",
     )
 
     mock_stop = mocker.patch("snsary.contrib.pypms.PollingSensor.stop")
@@ -121,7 +133,12 @@ def test_stop_bad_response(
     mock_stop.assert_called_once()
 
 
-def test_stop_already_closed(mocker, mock_sensor, sensor, caplog):
+def test_stop_already_closed(
+    mocker,
+    mock_sensor,
+    sensor,
+    caplog,
+):
     mocker.patch("snsary.contrib.pypms.PollingSensor.stop")
     sensor.stop()
 
@@ -129,7 +146,9 @@ def test_stop_already_closed(mocker, mock_sensor, sensor, caplog):
     assert "Attempting to use a port that is not open" in caplog.text
 
 
-def test_sample(sensor):
+def test_sample(
+    sensor,
+):
     readings = sensor.sample(timestamp="now", elapsed_seconds=0)
     assert len(readings) == 12
 
@@ -138,7 +157,9 @@ def test_sample(sensor):
     assert pm10_reading.timestamp == "now"
 
 
-def test_sample_warm_up(sensor):
+def test_sample_warm_up(
+    sensor,
+):
     sensor.warm_up_seconds = 5
     readings = sensor.sample(timestamp="now", elapsed_seconds=0)
     assert len(readings) == 0
@@ -151,9 +172,14 @@ def test_sample_warm_up(sensor):
     assert pm10_reading.timestamp == "now"
 
 
-def test_sample_bad_response(mock_sensor, sensor):
+def test_sample_bad_response(
+    mock_sensor,
+    sensor,
+):
     mock_sensor.stub(
-        name="passive_read", receive_bytes=b"BM\xe2\x00\x00\x01q", send_bytes=b"123"
+        name="passive_read",
+        receive_bytes=b"BM\xe2\x00\x00\x01q",
+        send_bytes=b"123",
     )
 
     with pytest.raises(pms.WrongMessageFormat):

--- a/tests/contrib/test_pypms.py
+++ b/tests/contrib/test_pypms.py
@@ -7,43 +7,43 @@ from snsary.contrib.pypms import PyPMSSensor
 @pytest.fixture
 def mock_sensor(mock_serial):
     mock_serial.stub(
-        name='wake',
-        receive_bytes=b'BM\xe4\x00\x01\x01t',
+        name="wake",
+        receive_bytes=b"BM\xe4\x00\x01\x01t",
         send_bytes=(
-            b'BM\x00\x1c' +  # expected header
-            b'..........................' +  # payload (to total 32 bytes)
-            b'\x05W'  # checksum = sum(header) + sum(payload)
-        )
+            b"BM\x00\x1c"
+            + b".........................."  # expected header
+            + b"\x05W"  # payload (to total 32 bytes)  # checksum = sum(header) + sum(payload)
+        ),
     )
 
     mock_serial.stub(
-        name='passive_mode',
-        receive_bytes=b'BM\xe1\x00\x00\x01p',
+        name="passive_mode",
+        receive_bytes=b"BM\xe1\x00\x00\x01p",
         send_bytes=(
-            b'BM\x00\x04' +  # expected header
-            b'..' +  # payload (to total 8 bytes)
-            b'\x00\xef'  # checksum
-        )
+            b"BM\x00\x04"
+            + b".."  # expected header
+            + b"\x00\xef"  # payload (to total 8 bytes)  # checksum
+        ),
     )
 
     mock_serial.stub(
-        name='passive_read',
-        receive_bytes=b'BM\xe2\x00\x00\x01q',
+        name="passive_read",
+        receive_bytes=b"BM\xe2\x00\x00\x01q",
         send_bytes=(
-            b'BM\x00\x1c' +  # expected header
-            b'..........................' +  # payload (to total 32 bytes)
-            b'\x05W'  # checksum
-        )
+            b"BM\x00\x1c"
+            + b".........................."  # expected header
+            + b"\x05W"  # payload (to total 32 bytes)  # checksum
+        ),
     )
 
     mock_serial.stub(
-        name='sleep',
-        receive_bytes=b'BM\xe4\x00\x00\x01s',
+        name="sleep",
+        receive_bytes=b"BM\xe4\x00\x00\x01s",
         send_bytes=(
-            b'BM\x00\x04' +  # expected header
-            b'..' +  # payload (to total 8 bytes)
-            b'\x00\xef'  # checksum
-        )
+            b"BM\x00\x04"
+            + b".."  # expected header
+            + b"\x00\xef"  # payload (to total 8 bytes)  # checksum
+        ),
     )
 
     return mock_serial
@@ -52,7 +52,7 @@ def mock_sensor(mock_serial):
 @pytest.fixture
 def sensor(mock_sensor):
     return PyPMSSensor(
-        sensor_name='PMSx003',
+        sensor_name="PMSx003",
         port=mock_sensor.port,
         warm_up_seconds=0,
         # timeout should be low to avoid failure tests
@@ -62,42 +62,29 @@ def sensor(mock_sensor):
 
 
 def test_name(sensor):
-    assert sensor.name == 'PMSx003'
+    assert sensor.name == "PMSx003"
 
 
 def test_init_sensor_not_found():
     with pytest.raises(Exception) as einfo:
-        PyPMSSensor(sensor_name='something', port='any')
+        PyPMSSensor(sensor_name="something", port="any")
 
-    assert 'KeyError' in str(einfo)
+    assert "KeyError" in str(einfo)
 
 
-def test_start(
-    mocker,
-    mock_sensor,
-    sensor
-):
-    mock_start = mocker.patch('snsary.contrib.pypms.PollingSensor.start')
+def test_start(mocker, mock_sensor, sensor):
+    mock_start = mocker.patch("snsary.contrib.pypms.PollingSensor.start")
     sensor.start()
 
-    assert mock_sensor.stubs['wake'].called
-    assert mock_sensor.stubs['passive_mode'].called
+    assert mock_sensor.stubs["wake"].called
+    assert mock_sensor.stubs["passive_mode"].called
     mock_start.assert_called_once()
 
 
-@pytest.mark.parametrize('send_bytes', [
-    b'',
-    b'123'
-])
-def test_start_bad_response(
-    mock_sensor,
-    sensor,
-    send_bytes
-):
+@pytest.mark.parametrize("send_bytes", [b"", b"123"])
+def test_start_bad_response(mock_sensor, sensor, send_bytes):
     mock_sensor.stub(
-        name='passive_mode',
-        receive_bytes=b'BM\xe1\x00\x00\x01p',
-        send_bytes=send_bytes
+        name="passive_mode", receive_bytes=b"BM\xe1\x00\x00\x01p", send_bytes=send_bytes
     )
 
     with pytest.raises(RuntimeError) as einfo:
@@ -111,10 +98,10 @@ def test_stop(
     mock_sensor,
     sensor,
 ):
-    mock_stop = mocker.patch('snsary.contrib.pypms.PollingSensor.stop')
+    mock_stop = mocker.patch("snsary.contrib.pypms.PollingSensor.stop")
     sensor.stop()
 
-    assert mock_sensor.stubs['sleep'].called
+    assert mock_sensor.stubs["sleep"].called
     mock_stop.assert_called_once()
 
 
@@ -124,79 +111,63 @@ def test_stop_bad_response(
     sensor,
 ):
     mock_sensor.stub(
-        name='sleep',
-        receive_bytes=b'BM\xe4\x00\x00\x01s',
-        send_bytes=b'123'
+        name="sleep", receive_bytes=b"BM\xe4\x00\x00\x01s", send_bytes=b"123"
     )
 
-    mock_stop = mocker.patch('snsary.contrib.pypms.PollingSensor.stop')
+    mock_stop = mocker.patch("snsary.contrib.pypms.PollingSensor.stop")
     sensor.stop()
 
-    assert mock_sensor.stubs['sleep'].called
+    assert mock_sensor.stubs["sleep"].called
     mock_stop.assert_called_once()
 
 
-def test_stop_already_closed(
-    mocker,
-    mock_sensor,
-    sensor,
-    caplog
-):
-    mocker.patch('snsary.contrib.pypms.PollingSensor.stop')
+def test_stop_already_closed(mocker, mock_sensor, sensor, caplog):
+    mocker.patch("snsary.contrib.pypms.PollingSensor.stop")
     sensor.stop()
 
     sensor.stop()
     assert "Attempting to use a port that is not open" in caplog.text
 
 
-def test_sample(
-    sensor
-):
-    readings = sensor.sample(timestamp='now', elapsed_seconds=0)
+def test_sample(sensor):
+    readings = sensor.sample(timestamp="now", elapsed_seconds=0)
     assert len(readings) == 12
 
-    pm10_reading = next(r for r in readings if r.name == 'pm10')
+    pm10_reading = next(r for r in readings if r.name == "pm10")
     assert pm10_reading.value == 11822
-    assert pm10_reading.timestamp == 'now'
+    assert pm10_reading.timestamp == "now"
 
 
-def test_sample_warm_up(
-    sensor
-):
+def test_sample_warm_up(sensor):
     sensor.warm_up_seconds = 5
-    readings = sensor.sample(timestamp='now', elapsed_seconds=0)
+    readings = sensor.sample(timestamp="now", elapsed_seconds=0)
     assert len(readings) == 0
 
-    readings = sensor.sample(timestamp='now', elapsed_seconds=5)
+    readings = sensor.sample(timestamp="now", elapsed_seconds=5)
     assert len(readings) == 12
 
-    pm10_reading = next(r for r in readings if r.name == 'pm10')
+    pm10_reading = next(r for r in readings if r.name == "pm10")
     assert pm10_reading.value == 11822
-    assert pm10_reading.timestamp == 'now'
+    assert pm10_reading.timestamp == "now"
 
 
-def test_sample_bad_response(
-    mock_sensor,
-    sensor
-):
+def test_sample_bad_response(mock_sensor, sensor):
     mock_sensor.stub(
-        name='passive_read',
-        receive_bytes=b'BM\xe2\x00\x00\x01q',
-        send_bytes=b'123'
+        name="passive_read", receive_bytes=b"BM\xe2\x00\x00\x01q", send_bytes=b"123"
     )
 
     with pytest.raises(pms.WrongMessageFormat):
-        sensor.sample(timestamp='now', elapsed_seconds=0)
+        sensor.sample(timestamp="now", elapsed_seconds=0)
 
 
 def test_sample_already_closed(
     mocker,
     sensor,
 ):
-    mocker.patch('snsary.contrib.pypms.PollingSensor.stop')
+    mocker.patch("snsary.contrib.pypms.PollingSensor.stop")
     sensor.stop()
 
     with pytest.raises(Exception) as einfo:
-        sensor.sample(timestamp='now', elapsed_seconds=0)
+        sensor.sample(timestamp="now", elapsed_seconds=0)
 
     assert str(einfo.value) == "Attempting to use a port that is not open"

--- a/tests/functions/test_filter.py
+++ b/tests/functions/test_filter.py
@@ -2,21 +2,21 @@ from snsary.functions import Filter
 
 
 def test_call():
-    assert Filter()('reading')
-    assert not Filter(lambda _: False)('reading')
+    assert Filter()("reading")
+    assert not Filter(lambda _: False)("reading")
 
 
 def test_sensor_name(reading):
-    assert not Filter.sensor_name('other')(reading)
-    assert Filter.sensor_name('mysensor')(reading)
+    assert not Filter.sensor_name("other")(reading)
+    assert Filter.sensor_name("mysensor")(reading)
 
 
 def test_invert():
-    assert not Filter().invert('reading')
-    assert Filter(lambda _: False).invert('reading')
+    assert not Filter().invert("reading")
+    assert Filter(lambda _: False).invert("reading")
 
 
 def test_names(reading):
     assert not Filter.names([])(reading)
-    assert not Filter.names('other')(reading)
-    assert Filter.names('other', 'myreading')(reading)
+    assert not Filter.names("other")(reading)
+    assert Filter.names("other", "myreading")(reading)

--- a/tests/functions/test_window.py
+++ b/tests/functions/test_window.py
@@ -14,42 +14,40 @@ def window():
 
 
 def test_call(window):
-    assert not window(create_reading(value=1, sensor_name='sensor1', timestamp=1))
-    assert not window(create_reading(value=2, sensor_name='sensor2', timestamp=1))
-    assert not window(create_reading(value=3, sensor_name='sensor1', timestamp=2))
-    assert not window(create_reading(value=4, sensor_name='sensor2', timestamp=2))
+    assert not window(create_reading(value=1, sensor_name="sensor1", timestamp=1))
+    assert not window(create_reading(value=2, sensor_name="sensor2", timestamp=1))
+    assert not window(create_reading(value=3, sensor_name="sensor1", timestamp=2))
+    assert not window(create_reading(value=4, sensor_name="sensor2", timestamp=2))
 
     # proves multiple readings are collected
-    readings = window(create_reading(value=5, sensor_name='sensor1', timestamp=3))
+    readings = window(create_reading(value=5, sensor_name="sensor1", timestamp=3))
     assert len(readings) == 1
-    assert readings[0].sensor_name == 'sensor1'
+    assert readings[0].sensor_name == "sensor1"
     assert readings[0].value == 1
 
-    assert not window(create_reading(value=5, sensor_name='sensor1', timestamp=4))
+    assert not window(create_reading(value=5, sensor_name="sensor1", timestamp=4))
 
     # prove that multiple windows are created
-    readings = window(create_reading(value=6, sensor_name='sensor2', timestamp=3))
+    readings = window(create_reading(value=6, sensor_name="sensor2", timestamp=3))
     assert len(readings) == 1
-    assert readings[0].sensor_name == 'sensor2'
+    assert readings[0].sensor_name == "sensor2"
     assert readings[0].value == 2
 
-    assert not window(create_reading(value=7, sensor_name='sensor2', timestamp=4))
+    assert not window(create_reading(value=7, sensor_name="sensor2", timestamp=4))
 
     # proves any order of aggregations is OK
-    readings = window(create_reading(value=8, sensor_name='sensor2', timestamp=5))
+    readings = window(create_reading(value=8, sensor_name="sensor2", timestamp=5))
     assert len(readings) == 1
-    assert readings[0].sensor_name == 'sensor2'
+    assert readings[0].sensor_name == "sensor2"
     assert readings[0].value == 6
 
     # proves aggregation is by period not size
-    assert not window(create_reading(value=8, sensor_name='sensor2', timestamp=5))
-    assert not window(create_reading(value=8, sensor_name='sensor2', timestamp=5))
+    assert not window(create_reading(value=8, sensor_name="sensor2", timestamp=5))
+    assert not window(create_reading(value=8, sensor_name="sensor2", timestamp=5))
 
 
 def test_call_restore(window, mock_store):
-    mock_store['window-2-mysensor-myreading'] = [
-        create_reading(timestamp=1, value=1)
-    ]
+    mock_store["window-2-mysensor-myreading"] = [create_reading(timestamp=1, value=1)]
 
     readings = window(create_reading(value=2, timestamp=3))
     assert len(readings) == 1
@@ -64,5 +62,5 @@ def test_stop(window, mock_store, reading):
     window(reading)
     window.stop()
 
-    assert 'window-2-mysensor-myreading' in mock_store
-    assert mock_store.get('window-2-mysensor-myreading') == [reading]
+    assert "window-2-mysensor-myreading" in mock_store
+    assert mock_store.get("window-2-mysensor-myreading") == [reading]

--- a/tests/functions/test_window.py
+++ b/tests/functions/test_window.py
@@ -47,7 +47,9 @@ def test_call(window):
 
 
 def test_call_restore(window, mock_store):
-    mock_store["window-2-mysensor-myreading"] = [create_reading(timestamp=1, value=1)]
+    mock_store["window-2-mysensor-myreading"] = [
+        create_reading(timestamp=1, value=1),
+    ]
 
     readings = window(create_reading(value=2, timestamp=3))
     assert len(readings) == 1

--- a/tests/functions/test_window_average.py
+++ b/tests/functions/test_window_average.py
@@ -5,10 +5,12 @@ from tests.conftest import create_reading
 def test_aggregate():
     window = WindowAverage(seconds=2)
 
-    readings = window.aggregate([
-        create_reading(value=1, timestamp=1),
-        create_reading(value=2, timestamp=2),
-    ])
+    readings = window.aggregate(
+        [
+            create_reading(value=1, timestamp=1),
+            create_reading(value=2, timestamp=2),
+        ]
+    )
 
     assert len(readings) == 1
     assert readings[0].value == 1.5

--- a/tests/functions/test_window_summary.py
+++ b/tests/functions/test_window_summary.py
@@ -5,17 +5,19 @@ from tests.conftest import create_reading
 def test_aggregate():
     window = WindowSummary(seconds=2)
 
-    readings = window.aggregate([
-        create_reading(value=1, timestamp=1),
-        create_reading(value=2, timestamp=2),
-    ])
+    readings = window.aggregate(
+        [
+            create_reading(value=1, timestamp=1),
+            create_reading(value=2, timestamp=2),
+        ]
+    )
 
     assert len(readings) == 4
-    assert readings[0].name == 'myreading--mean'
+    assert readings[0].name == "myreading--mean"
     assert readings[0].value == 1.5
-    assert readings[1].name == 'myreading--max'
+    assert readings[1].name == "myreading--max"
     assert readings[1].value == 2
-    assert readings[2].name == 'myreading--min'
+    assert readings[2].name == "myreading--min"
     assert readings[2].value == 1
-    assert readings[3].name == 'myreading--p50'
+    assert readings[3].name == "myreading--p50"
     assert readings[3].value == 1.5

--- a/tests/outputs/test_batch_output.py
+++ b/tests/outputs/test_batch_output.py
@@ -34,12 +34,18 @@ def test_stop(
     mock_publish_batch.assert_called_with(["reading"])
 
 
-def test_flush_empty(output, mock_publish_batch):
+def test_flush_empty(
+    output,
+    mock_publish_batch,
+):
     output.flush()
     mock_publish_batch.assert_not_called()
 
 
-def test_publish_forwards_large_batches(output, mock_publish_batch):
+def test_publish_forwards_large_batches(
+    output,
+    mock_publish_batch,
+):
     for _ in range(1, 101):
         output.publish("reading")
 

--- a/tests/outputs/test_batch_output.py
+++ b/tests/outputs/test_batch_output.py
@@ -17,7 +17,7 @@ def output():
 
 @pytest.fixture()
 def mock_publish_batch(output, mocker):
-    return mocker.patch.object(output, 'publish_batch')
+    return mocker.patch.object(output, "publish_batch")
 
 
 def test_stop(
@@ -27,38 +27,32 @@ def test_stop(
     output.stop()
     mock_publish_batch.assert_not_called()
 
-    output.publish('reading')
+    output.publish("reading")
     mock_publish_batch.assert_not_called()
 
     output.stop()
-    mock_publish_batch.assert_called_with(['reading'])
+    mock_publish_batch.assert_called_with(["reading"])
 
 
-def test_flush_empty(
-    output,
-    mock_publish_batch
-):
+def test_flush_empty(output, mock_publish_batch):
     output.flush()
     mock_publish_batch.assert_not_called()
 
 
-def test_publish_forwards_large_batches(
-    output,
-    mock_publish_batch
-):
+def test_publish_forwards_large_batches(output, mock_publish_batch):
     for _ in range(1, 101):
-        output.publish('reading')
+        output.publish("reading")
 
-    mock_publish_batch.assert_called_with(['reading'] * 100)
+    mock_publish_batch.assert_called_with(["reading"] * 100)
 
 
 def test_publish_forwards_old_batches(
     output,
     mock_publish_batch,
 ):
-    output.publish('reading')
+    output.publish("reading")
 
     with freeze_time(datetime.now() + timedelta(seconds=10)):
-        output.publish('reading')
+        output.publish("reading")
 
-    mock_publish_batch.assert_called_with(['reading'] * 2)
+    mock_publish_batch.assert_called_with(["reading"] * 2)

--- a/tests/sources/test_multi_source.py
+++ b/tests/sources/test_multi_source.py
@@ -3,6 +3,6 @@ from snsary.sources import MultiSource
 
 def test_subscribe(mocker):
     source = MultiSource()
-    mock_stream = mocker.patch.object(source.stream, 'subscribe')
-    source.subscribe('output')
-    mock_stream.assert_called_with('output')
+    mock_stream = mocker.patch.object(source.stream, "subscribe")
+    source.subscribe("output")
+    mock_stream.assert_called_with("output")

--- a/tests/sources/test_polling_sensor.py
+++ b/tests/sources/test_polling_sensor.py
@@ -3,7 +3,9 @@ import logging
 from snsary.sources import PollingSensor
 
 
-def test_tick_copes_with_generators(caplog):
+def test_tick_copes_with_generators(
+    caplog,
+):
     class TestSensor(PollingSensor):
         def __init__(self):
             PollingSensor.__init__(self, period_seconds=5)

--- a/tests/sources/test_polling_sensor.py
+++ b/tests/sources/test_polling_sensor.py
@@ -3,15 +3,13 @@ import logging
 from snsary.sources import PollingSensor
 
 
-def test_tick_copes_with_generators(
-    caplog
-):
+def test_tick_copes_with_generators(caplog):
     class TestSensor(PollingSensor):
         def __init__(self):
             PollingSensor.__init__(self, period_seconds=5)
 
         def sample(self, **kwargs):
-            yield 'reading'
+            yield "reading"
 
     caplog.set_level(logging.INFO)
     TestSensor().tick()

--- a/tests/sources/test_sensor.py
+++ b/tests/sources/test_sensor.py
@@ -1,4 +1,4 @@
 def test_subscribe(mocker, sensor):
-    mock_stream = mocker.patch.object(sensor.stream, 'subscribe')
-    sensor.subscribe('output')
-    mock_stream.assert_called_with('output')
+    mock_stream = mocker.patch.object(sensor.stream, "subscribe")
+    sensor.subscribe("output")
+    mock_stream.assert_called_with("output")

--- a/tests/streams/test_simple_stream.py
+++ b/tests/streams/test_simple_stream.py
@@ -11,10 +11,10 @@ def test_publish_exception(caplog):
     stream.subscribe(MockOutput(index=1))
 
     caplog.set_level(logging.INFO)
-    stream.publish('reading')
+    stream.publish("reading")
 
     def assertions():
-        assert 'ERROR - [snsary.mockoutput-0] problem-1' in caplog.text
-        assert 'INFO - [snsary.mockoutput-1] Reading' in caplog.text
+        assert "ERROR - [snsary.mockoutput-0] problem-1" in caplog.text
+        assert "INFO - [snsary.mockoutput-1] Reading" in caplog.text
 
     retry(assertions)

--- a/tests/streams/test_stream.py
+++ b/tests/streams/test_stream.py
@@ -52,7 +52,12 @@ def test_average(stream, output):
     stream.average(seconds=2).into(output)
 
     for i in range(3):
-        stream.publish(create_reading(value=i + 1, timestamp=i))
+        stream.publish(
+            create_reading(
+                value=i + 1,
+                timestamp=i,
+            )
+        )
 
     assert len(output.readings) == 1
     assert output.readings[0].value == 1.5
@@ -62,7 +67,12 @@ def test_summarize(stream, output):
     stream.summarize(seconds=2).into(output)
 
     for i in range(3):
-        stream.publish(create_reading(value=i + 1, timestamp=i))
+        stream.publish(
+            create_reading(
+                value=i + 1,
+                timestamp=i,
+            )
+        )
 
     assert len(output.readings) == 4
     assert output.readings[0].name == "myreading--mean"

--- a/tests/streams/test_stream.py
+++ b/tests/streams/test_stream.py
@@ -40,21 +40,19 @@ def test_apply(stream, output):
 
 
 def test_filter_names(stream, output):
-    stream.filter_names('pass').into(output)
-    stream.publish(create_reading(name='fail'))
-    stream.publish(create_reading(name='pass'))
+    stream.filter_names("pass").into(output)
+    stream.publish(create_reading(name="fail"))
+    stream.publish(create_reading(name="pass"))
 
     assert len(output.readings) == 1
-    assert output.readings[0].name == 'pass'
+    assert output.readings[0].name == "pass"
 
 
 def test_average(stream, output):
     stream.average(seconds=2).into(output)
 
     for i in range(3):
-        stream.publish(create_reading(
-            value=i+1, timestamp=i
-        ))
+        stream.publish(create_reading(value=i + 1, timestamp=i))
 
     assert len(output.readings) == 1
     assert output.readings[0].value == 1.5
@@ -64,20 +62,21 @@ def test_summarize(stream, output):
     stream.summarize(seconds=2).into(output)
 
     for i in range(3):
-        stream.publish(create_reading(
-            value=i+1, timestamp=i
-        ))
+        stream.publish(create_reading(value=i + 1, timestamp=i))
 
     assert len(output.readings) == 4
-    assert output.readings[0].name == 'myreading--mean'
+    assert output.readings[0].name == "myreading--mean"
     assert output.readings[0].value == 1.5
 
 
-@pytest.mark.parametrize('kwargs,expected', [
-    ({'append': 'foo'}, 'myreadingfoo'),
-    ({'to': 'bar'}, 'bar'),
-    ({'append': 'foo', 'to': 'bar'}, 'barfoo')
-])
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"append": "foo"}, "myreadingfoo"),
+        ({"to": "bar"}, "bar"),
+        ({"append": "foo", "to": "bar"}, "barfoo"),
+    ],
+)
 def test_rename(stream, output, kwargs, expected):
     stream.rename(**kwargs).into(output)
     stream.publish(create_reading())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,19 +28,19 @@ def test_system(caplog):
     outputs = [MockOutput(), MockOutput(index=1)]
 
     def first_assertions():
-        assert 'INFO - [snsary] Started.' in caplog.text
-        assert 'INFO - [snsary.mocksensor-0] Collected 1 readings.' in caplog.text
-        assert 'INFO - [snsary.mockoutput-0] Reading: <abc 1650885071 0>' in caplog.text
-        assert 'INFO - [snsary.mockoutput-1] Reading: <abc 1650885071 0>' in caplog.text
+        assert "INFO - [snsary] Started." in caplog.text
+        assert "INFO - [snsary.mocksensor-0] Collected 1 readings." in caplog.text
+        assert "INFO - [snsary.mockoutput-0] Reading: <abc 1650885071 0>" in caplog.text
+        assert "INFO - [snsary.mockoutput-1] Reading: <abc 1650885071 0>" in caplog.text
 
     def second_assertions():
-        assert 'INFO - [snsary.mockoutput-0] Reading: <abc 1650885072 1>' in caplog.text
-        assert 'INFO - [snsary.mockoutput-1] Reading: <abc 1650885072 1>' in caplog.text
+        assert "INFO - [snsary.mockoutput-0] Reading: <abc 1650885072 1>" in caplog.text
+        assert "INFO - [snsary.mockoutput-1] Reading: <abc 1650885072 1>" in caplog.text
 
     def end_assertions():
-        assert 'INFO - [snsary] Stopping.' in caplog.text
-        assert 'INFO - [snsary] Bye.' in caplog.text
-        assert 'ERROR' not in caplog.text
+        assert "INFO - [snsary] Stopping." in caplog.text
+        assert "INFO - [snsary] Bye." in caplog.text
+        assert "ERROR" not in caplog.text
 
     with time_machine.travel("2022-04-25T12:11:11+01:00", tick=False) as frozen_time:
         with tmp_app(sensors=sensors, outputs=outputs):
@@ -55,8 +55,8 @@ def test_failing_sensor(caplog):
     sensors = [MockSensor(fail=True, period_seconds=1)]
 
     def assertions():
-        assert 'ERROR - [snsary.mocksensor-0] problem-1' in caplog.text
-        assert 'ERROR - [snsary.mocksensor-0] problem-2' in caplog.text
+        assert "ERROR - [snsary.mocksensor-0] problem-1" in caplog.text
+        assert "ERROR - [snsary.mocksensor-0] problem-2" in caplog.text
 
     with tmp_app(sensors=sensors):
         retry(assertions)
@@ -68,9 +68,9 @@ def test_failing_output(caplog):
     outputs = [MockOutput(fail=True)]
 
     def assertions():
-        assert 'INFO - [snsary.mocksensor-0] Collected 1 readings.' in caplog.text
-        assert 'ERROR - [snsary.mockoutput-0] problem-1' in caplog.text
-        assert 'ERROR - [snsary.mockoutput-0] problem-2' in caplog.text
+        assert "INFO - [snsary.mocksensor-0] Collected 1 readings." in caplog.text
+        assert "ERROR - [snsary.mockoutput-0] problem-1" in caplog.text
+        assert "ERROR - [snsary.mockoutput-0] problem-2" in caplog.text
 
     with tmp_app(sensors=sensors, outputs=outputs):
         retry(assertions)
@@ -81,14 +81,14 @@ def test_stuck_sensor_service(caplog):
     sensors = [MockSensor(hang=True), MockSensor(index=1)]
 
     def assertions():
-        assert 'INFO - [snsary.mocksensor-1] Collected 1 readings.' in caplog.text
-        assert 'INFO - [snsary.mocksensor-0] Collected 1 readings.' not in caplog.text
+        assert "INFO - [snsary.mocksensor-1] Collected 1 readings." in caplog.text
+        assert "INFO - [snsary.mocksensor-0] Collected 1 readings." not in caplog.text
 
     with tmp_app(sensors=sensors):
         retry(assertions)
 
     def end_assertions():
-        assert 'ERROR - [snsary.mocksensor-0] Failed to stop.' in caplog.text
+        assert "ERROR - [snsary.mocksensor-0] Failed to stop." in caplog.text
 
     retry(end_assertions)
 
@@ -99,24 +99,21 @@ def test_stuck_output_async(caplog):
     outputs = [MockOutput(hang=True), MockOutput(index=1)]
 
     def assertions():
-        assert 'INFO - [snsary.mockoutput-1] Reading' in caplog.text
-        assert 'INFO - [snsary.mockoutput-0] Reading' not in caplog.text
+        assert "INFO - [snsary.mockoutput-1] Reading" in caplog.text
+        assert "INFO - [snsary.mockoutput-0] Reading" not in caplog.text
 
     with tmp_app(sensors=sensors, outputs=outputs):
         retry(assertions)
 
     def end_assertions():
-        assert 'Bye.' in caplog.text
-        assert 'ERROR' not in caplog.text
+        assert "Bye." in caplog.text
+        assert "ERROR" not in caplog.text
 
     retry(end_assertions)
 
 
 def test_wait_stop():
-    thread = Thread(
-        target=lambda: system.wait(handle_signals=False),
-        daemon=True
-    )
+    thread = Thread(target=lambda: system.wait(handle_signals=False), daemon=True)
 
     thread.start()
     thread.join(timeout=0.1)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -113,7 +113,10 @@ def test_stuck_output_async(caplog):
 
 
 def test_wait_stop():
-    thread = Thread(target=lambda: system.wait(handle_signals=False), daemon=True)
+    thread = Thread(
+        target=lambda: system.wait(handle_signals=False),
+        daemon=True,
+    )
 
     thread.start()
     thread.join(timeout=0.1)

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -47,5 +47,7 @@ def test_configure_logging(mocker):
     configure_logging()
 
     mock_config.assert_called_with(
-        stream=sys.stdout, level=logging.INFO, format=mocker.ANY
+        stream=sys.stdout,
+        level=logging.INFO,
+        format=mocker.ANY,
     )

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -7,33 +7,33 @@ from tests.conftest import retry
 
 
 def test_HasLogger_name():
-    assert HasLogger().name == 'HasLogger'
+    assert HasLogger().name == "HasLogger"
 
 
 def test_HasLogger_logger():
-    assert HasLogger().logger.name == 'snsary.haslogger'
+    assert HasLogger().logger.name == "snsary.haslogger"
 
 
 def test_get_logger_main_thread():
-    assert get_logger().name == 'snsary'
+    assert get_logger().name == "snsary"
 
 
 def test_get_logger_not_found(mocker):
-    mock_thread = mocker.patch('snsary.utils.logger.current_thread')
-    mock_thread().ident = 'rand'  # mock ident to avoid reuse issues
-    assert get_logger().name == 'snsary.anon-rand'
+    mock_thread = mocker.patch("snsary.utils.logger.current_thread")
+    mock_thread().ident = "rand"  # mock ident to avoid reuse issues
+    assert get_logger().name == "snsary.anon-rand"
 
 
 def test_get_logger_child_thread(caplog):
     caplog.set_level(logging.INFO)
 
     def in_a_thread():
-        get_logger('foo').warning("testing")
+        get_logger("foo").warning("testing")
         get_logger().info("success")
 
     def assertions():
-        assert 'WARNING - [snsary.foo] testing' in caplog.text
-        assert 'INFO - [snsary.foo] success' in caplog.text
+        assert "WARNING - [snsary.foo] testing" in caplog.text
+        assert "INFO - [snsary.foo] success" in caplog.text
 
     thread = Thread(target=in_a_thread)
     thread.start()
@@ -43,11 +43,9 @@ def test_get_logger_child_thread(caplog):
 
 
 def test_configure_logging(mocker):
-    mock_config = mocker.patch('logging.basicConfig')
+    mock_config = mocker.patch("logging.basicConfig")
     configure_logging()
 
     mock_config.assert_called_with(
-        stream=sys.stdout,
-        level=logging.INFO,
-        format=mocker.ANY
+        stream=sys.stdout, level=logging.INFO, format=mocker.ANY
     )

--- a/tests/utils/test_scraper.py
+++ b/tests/utils/test_scraper.py
@@ -4,58 +4,36 @@ import pytest
 
 from snsary.utils import scraper
 
-test_namedtuple = namedtuple(
-    'test', ['string', 'int', 'float']
+test_namedtuple = namedtuple("test", ["string", "int", "float"])
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (1, [("prefix", 1)]),
+        (1.23, [("prefix", 1.23)]),
+        ("a-string", []),
+        (
+            [test_namedtuple("a-string", 1, 1.23)],
+            [
+                ("prefix-0-int", 1),
+                ("prefix-0-float", 1.23),
+            ],
+        ),
+        (("a-string", 1, 1.23), [("prefix-1", 1), ("prefix-2", 1.23)]),
+        (
+            {"key1": ("a-string",), "key2": 1, "key3": (1.23,)},
+            [("prefix-key2", 1), ("prefix-key3-0", 1.23)],
+        ),
+    ],
 )
-
-
-@pytest.mark.parametrize('value, expected', [
-    (
-        1, [('prefix', 1)]
-    ),
-    (
-        1.23, [('prefix', 1.23)]
-    ),
-    (
-        'a-string', []
-    ),
-    (
-        [
-            test_namedtuple('a-string', 1, 1.23)
-        ],
-        [
-            ('prefix-0-int', 1),
-            ('prefix-0-float', 1.23),
-        ]
-    ),
-    (
-        ('a-string', 1, 1.23),
-        [
-            ('prefix-1', 1),
-            ('prefix-2', 1.23)
-        ]
-    ),
-    (
-        {
-            'key1': ('a-string',),
-            'key2': 1,
-            'key3': (1.23,)
-        },
-        [
-            ('prefix-key2', 1),
-            ('prefix-key3-0', 1.23)
-        ]
-    )
-])
 def test_extract_from(value, expected):
-    assert list(
-        scraper.extract_from(value, prefix='prefix')
-    ) == expected
+    assert list(scraper.extract_from(value, prefix="prefix")) == expected
 
 
 def test_for_class():
     class MockClass:
-        __slots__ = ['slot_1']
+        __slots__ = ["slot_1"]
 
         def __init__(self):
             self.slot_1 = (1.1, 2.2)
@@ -72,8 +50,8 @@ def test_for_class():
     results = class_scraper(MockClass())
 
     assert list(results) == [
-        ('prop_1-0', 1.1),
-        ('prop_1-1', 2.2),
-        ('slot_1-0', 1.1),
-        ('slot_1-1', 2.2),
+        ("prop_1-0", 1.1),
+        ("prop_1-1", 2.2),
+        ("slot_1-0", 1.1),
+        ("slot_1-1", 2.2),
     ]

--- a/tests/utils/test_scraper.py
+++ b/tests/utils/test_scraper.py
@@ -4,26 +4,54 @@ import pytest
 
 from snsary.utils import scraper
 
-test_namedtuple = namedtuple("test", ["string", "int", "float"])
+test_namedtuple = namedtuple(
+    "test",
+    ["string", "int", "float"],
+)
 
 
 @pytest.mark.parametrize(
     "value, expected",
     [
-        (1, [("prefix", 1)]),
-        (1.23, [("prefix", 1.23)]),
+        (
+            1,
+            [
+                ("prefix", 1),
+            ],
+        ),
+        (
+            1.23,
+            [
+                ("prefix", 1.23),
+            ],
+        ),
         ("a-string", []),
         (
-            [test_namedtuple("a-string", 1, 1.23)],
+            [
+                test_namedtuple("a-string", 1, 1.23),
+            ],
             [
                 ("prefix-0-int", 1),
                 ("prefix-0-float", 1.23),
             ],
         ),
-        (("a-string", 1, 1.23), [("prefix-1", 1), ("prefix-2", 1.23)]),
         (
-            {"key1": ("a-string",), "key2": 1, "key3": (1.23,)},
-            [("prefix-key2", 1), ("prefix-key3-0", 1.23)],
+            ("a-string", 1, 1.23),
+            [
+                ("prefix-1", 1),
+                ("prefix-2", 1.23),
+            ],
+        ),
+        (
+            {
+                "key1": ("a-string",),
+                "key2": 1,
+                "key3": (1.23,),
+            },
+            [
+                ("prefix-key2", 1),
+                ("prefix-key3-0", 1.23),
+            ],
         ),
     ],
 )

--- a/tests/utils/test_scraper.py
+++ b/tests/utils/test_scraper.py
@@ -56,7 +56,8 @@ test_namedtuple = namedtuple(
     ],
 )
 def test_extract_from(value, expected):
-    assert list(scraper.extract_from(value, prefix="prefix")) == expected
+    scraps = scraper.extract_from(value, prefix="prefix")
+    assert list(scraps) == expected
 
 
 def test_for_class():

--- a/tests/utils/test_storage.py
+++ b/tests/utils/test_storage.py
@@ -8,7 +8,7 @@ from snsary.utils.storage import _get_storage_backend, get_storage
 
 @pytest.fixture
 def storage_path(mocker, tmp_path):
-    path = str(tmp_path / 'test.ss')
+    path = str(tmp_path / "test.ss")
     mocker.patch.dict(os.environ, STORAGE_PATH=path)
     return path
 
@@ -17,10 +17,10 @@ def test_get_storage(mocker):
     mocker.patch.dict(os.environ, {}, clear=True)
     store = get_storage()
 
-    assert '__getitem__' in dir(store)
-    assert '__contains__' in dir(store)
-    assert '__setitem__' in dir(store)
-    assert 'clear' in dir(store)
+    assert "__getitem__" in dir(store)
+    assert "__contains__" in dir(store)
+    assert "__setitem__" in dir(store)
+    assert "clear" in dir(store)
     assert id(store) == id(get_storage())
 
 
@@ -31,40 +31,40 @@ def test_get_storage_backend_mock(mocker):
 
 def test_get_storage_backend(storage_path):
     data = pickle.dumps(dict(test=123))
-    open(storage_path, 'wb').write(data)
-    assert _get_storage_backend()['test'] == 123
+    open(storage_path, "wb").write(data)
+    assert _get_storage_backend()["test"] == 123
 
 
 def test_get_storage_backend_not_exist(storage_path):
     backend = _get_storage_backend()
     assert backend.ttl == 86400
-    assert backend.maxsize == float('inf')
+    assert backend.maxsize == float("inf")
 
 
 def test_get_storage_backend_ttl(storage_path, mocker):
-    mocker.patch.dict(os.environ, STORAGE_TTL='123')
+    mocker.patch.dict(os.environ, STORAGE_TTL="123")
     assert _get_storage_backend().ttl == 123
 
 
 def test_get_storage_backend_corrupt(storage_path):
-    open(storage_path, 'wb').write(b'something')
+    open(storage_path, "wb").write(b"something")
     assert len(_get_storage_backend()) == 0
 
 
 def test_get_storage_backend_empty(storage_path):
-    open(storage_path, 'wb').close()
+    open(storage_path, "wb").close()
     assert os.path.exists(storage_path)
     assert len(_get_storage_backend()) == 0
 
 
 def test_get_storage_backend_at_exit(mocker, storage_path):
-    mock_atexit = mocker.patch('atexit.register')
+    mock_atexit = mocker.patch("atexit.register")
 
     backend = _get_storage_backend()
     mock_atexit.assert_called()
 
-    backend['test'] = 123
+    backend["test"] = 123
     mock_atexit.mock_calls[0].args[0]()
 
-    backend = pickle.load(open(storage_path, 'rb'))
-    assert backend['test'] == 123
+    backend = pickle.load(open(storage_path, "rb"))
+    assert backend["test"] == 123

--- a/tests/utils/test_tracker.py
+++ b/tests/utils/test_tracker.py
@@ -8,7 +8,7 @@ from tests.conftest import create_reading
 def tracker():
     class FakeTracker(Tracker):
         def __init__(self):
-            Tracker.__init__(self, 'FakeTracker', foo=max, bar=min)
+            Tracker.__init__(self, "FakeTracker", foo=max, bar=min)
 
         def on_change(self, old, new):
             self.changed_old = old
@@ -19,48 +19,47 @@ def tracker():
 
 def test_update(tracker, mock_store):
     readings = [
-        create_reading(name='foo', value=1),
-        create_reading(name='bar', value=2),
-        create_reading(name='other')
+        create_reading(name="foo", value=1),
+        create_reading(name="bar", value=2),
+        create_reading(name="other"),
     ]
 
-    old_values = {'foo': 0, 'bar': 1}
-    mock_store['FakeTracker-tracked-values'] = old_values
+    old_values = {"foo": 0, "bar": 1}
+    mock_store["FakeTracker-tracked-values"] = old_values
 
     tracker.update(readings)
     assert tracker.changed_old == old_values
 
-    expected_values = {'foo': 1, 'bar': 1}
-    assert mock_store['FakeTracker-tracked-values'] == expected_values
+    expected_values = {"foo": 1, "bar": 1}
+    assert mock_store["FakeTracker-tracked-values"] == expected_values
     assert tracker.changed_new == expected_values
 
 
 def test_update_no_store(tracker, mock_store):
     readings = [
-        create_reading(name='foo', value=1),
-        create_reading(name='bar', value=2),
+        create_reading(name="foo", value=1),
+        create_reading(name="bar", value=2),
     ]
 
     tracker.update(readings)
     assert tracker.changed_old == {}
 
-    expected_values = {'foo': 1, 'bar': 2}
-    assert mock_store['FakeTracker-tracked-values'] == expected_values
+    expected_values = {"foo": 1, "bar": 2}
+    assert mock_store["FakeTracker-tracked-values"] == expected_values
     assert tracker.changed_new == expected_values
 
 
-@pytest.mark.parametrize('readings', [
-    [create_reading(name='foo')],
-    [create_reading(name='foo', value=1), create_reading(name='bar', value=2)],
-])
-def test_update_no_change(
-    tracker,
-    mock_store,
-    readings
-):
-    expected_values = {'foo': 1, 'bar': 2}
-    mock_store['FakeTracker-tracked-values'] = expected_values
+@pytest.mark.parametrize(
+    "readings",
+    [
+        [create_reading(name="foo")],
+        [create_reading(name="foo", value=1), create_reading(name="bar", value=2)],
+    ],
+)
+def test_update_no_change(tracker, mock_store, readings):
+    expected_values = {"foo": 1, "bar": 2}
+    mock_store["FakeTracker-tracked-values"] = expected_values
 
     tracker.update(readings)
-    assert 'changed_new' not in dir(tracker)
-    assert mock_store['FakeTracker-tracked-values'] == expected_values
+    assert "changed_new" not in dir(tracker)
+    assert mock_store["FakeTracker-tracked-values"] == expected_values


### PR DESCRIPTION
This removes unnecessary formatting decisions:

- Quotes are all double quotes
- Newlines are used deterministicaly

In the latter case, the removal of newlines has exposed a few areas
of code that relied on formatting to manage complexity, the common
example being nested comprehensions; this change also rewrites
some of the affected areas to be less dense.