### PR TITLE
Add tracing utility to reduce noisy errors

### DIFF
--- a/docs/examples/contrib.py
+++ b/docs/examples/contrib.py
@@ -28,9 +28,9 @@ logging.configure_logging()
 
 tracing.configure(
     {
-        "*.enabled": True,
-        "*.monitors": [tracing.LivenessAlert.factory(), tracing.GapAlert.factory()],
-        "*.thread_aware": True,
+        "enabled": True,
+        "monitors": [tracing.LivenessAlert.factory(), tracing.GapAlert.factory()],
+        "thread_aware": True,
     }
 )
 

--- a/docs/examples/contrib.py
+++ b/docs/examples/contrib.py
@@ -20,11 +20,19 @@ from snsary.contrib.psutil import PSUtilSensor
 from snsary.contrib.pypms import PyPMSSensor
 from snsary.sources import MultiSource
 from snsary.streams import SimpleStream
-from snsary.utils import logging
+from snsary.utils import logging, tracing
 
 i2c = board.I2C()
 load_dotenv()
 logging.configure_logging()
+
+tracing.configure(
+    {
+        "*.enabled": True,
+        "*.monitors": [tracing.LivenessAlert.factory(), tracing.GapAlert.factory()],
+        "*.thread_aware": True,
+    }
+)
 
 # summarization is necessary to minimise the amount of data stored but also
 # for GraphQL to make longterm queries practical in the absence of grouping

--- a/src/snsary/outputs/batch_output.py
+++ b/src/snsary/outputs/batch_output.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from wrapt import synchronized
 
 from snsary import system
+from snsary.utils import tracing
 
 from .output import Output
 
@@ -21,6 +22,7 @@ class BatchOutput(Output, system.Service):
         self.__max_wait_seconds = max_wait_seconds
         self.__last_publish = datetime.utcnow().timestamp()
 
+    @tracing.capture_exceptions("snsary.outputs.batch_output")
     def flush(self):
         # in case of multiple consecutive batch/age flushes
         if not self.__readings:

--- a/src/snsary/sources/poller.py
+++ b/src/snsary/sources/poller.py
@@ -26,7 +26,11 @@ class Poller(system.Service):
     def __loop(self):
         while not self.__stop.is_set():
             now = datetime.now().astimezone()
-            self.tick(**self.__tick_kwargs(now))
+
+            try:
+                self.tick(**self.__tick_kwargs(now))
+            except Exception as e:
+                self.logger.exception(e)
 
             now2 = datetime.now().astimezone()
             delay = int((now2 - now).total_seconds())

--- a/src/snsary/sources/polling_sensor.py
+++ b/src/snsary/sources/polling_sensor.py
@@ -1,3 +1,5 @@
+from snsary.utils import tracing
+
 from .poller import Poller
 from .sensor import Sensor
 
@@ -9,6 +11,7 @@ class PollingSensor(Sensor, Poller):
         Sensor.__init__(self)
         Poller.__init__(self, period_seconds=period_seconds)
 
+    @tracing.capture_exceptions("snsary.sources.polling_sensor")
     def tick(self, **kwargs):
         readings = list(self.sample(**kwargs))
         self.logger.info(f"Collected {len(readings)} readings.")

--- a/src/snsary/sources/polling_sensor.py
+++ b/src/snsary/sources/polling_sensor.py
@@ -10,14 +10,11 @@ class PollingSensor(Sensor, Poller):
         Poller.__init__(self, period_seconds=period_seconds)
 
     def tick(self, **kwargs):
-        try:
-            readings = list(self.sample(**kwargs))
-            self.logger.info(f"Collected {len(readings)} readings.")
+        readings = list(self.sample(**kwargs))
+        self.logger.info(f"Collected {len(readings)} readings.")
 
-            for reading in readings:
-                self.stream.publish(reading)
-        except Exception as e:
-            self.logger.exception(e)
+        for reading in readings:
+            self.stream.publish(reading)
 
     def sample(self, **kwargs):
         raise NotImplementedError()

--- a/src/snsary/utils/tracing/__init__.py
+++ b/src/snsary/utils/tracing/__init__.py
@@ -7,16 +7,16 @@ Tracing utility with a ``capture_exceptions`` decorator that instruments a given
 
     tracing.configure({
         # tracing is disabled by default
-        "*.enabled": True,
+        "enabled": True,
 
         # specify how to look for errors
-        "*.monitors": [
+        "monitors": [
             tracing.GapsAlert.factory(),
             tracing.LivenessAlert.factory(),
         ],
 
         # monitor each thread separately
-        "*.thread_aware": True,
+        "thread_aware": True,
     })
 
 With this config, the tracing system will create a new instance of each :mod:`Monitor <snsary.utils.tracing.monitors>` for each function being traced and each thread that calls the function. You can change this behaviour on a per-function basis. For example, customising ``some.unique.path`` looks like this: ::

--- a/src/snsary/utils/tracing/__init__.py
+++ b/src/snsary/utils/tracing/__init__.py
@@ -1,0 +1,55 @@
+"""
+Tracing utility with a ``capture_exceptions`` decorator that instruments a given function to monitor success and failure (exceptions) over time; exceptions are captured and logged as warnings. Basic usage of the tracing utility looks like this (with global configuration): ::
+
+    @tracing.capture_exceptions("some.unique.path")
+    def noisy_error_function():
+        ...
+
+    tracing.configure({
+        # tracing is disabled by default
+        "*.enabled": True,
+
+        # specify how to look for errors
+        "*.monitors": [
+            tracing.GapsAlert.factory(),
+            tracing.LivenessAlert.factory(),
+        ],
+
+        # monitor each thread separately
+        "*.thread_aware": True,
+    })
+
+With this config, the tracing system will create a new instance of each :mod:`Monitor <snsary.utils.tracing.monitors>` for each function being traced and each thread that calls the function. You can change this behaviour on a per-function basis. For example, customising ``some.unique.path`` looks like this: ::
+
+    tracing.configure({
+        "some.unique.path.monitors": [
+            tracing.GapsMonitor.factory(
+                max_gaps=5,
+                history=SimpleHistory(max_length=10),
+            )
+        ]
+    })
+
+
+See the :mod:`Config <snsary.utils.tracing.config>` module for more details.
+"""
+
+from .config import Config
+from .core import capture_exceptions, configure, reset
+from .history import History
+from .monitors import GapAlert, LivenessAlert, Monitor
+from .registry import Registry
+from .sample import Sample
+
+__all__ = [
+    "capture_exceptions",
+    "configure",
+    "GapAlert",
+    "LivenessAlert",
+    "Sample",
+    "Monitor",
+    "reset",
+    "History",
+    "Config",
+    "Registry",
+]

--- a/src/snsary/utils/tracing/config.py
+++ b/src/snsary/utils/tracing/config.py
@@ -1,0 +1,81 @@
+"""
+Hierarchical key / value store with keys written using dot notation e.g. ``some.id.attribute``. Basic getting and setting of values is simple: ::
+
+    config.set("some.id.attribute", "value")
+    config.get("some.id.attribute")  # => "value"
+
+Keys can also contain one or more ``*`` placeholders, each of which match one or more parts. This makes it possible to define "defaults" that apply to more specific keys e.g. ::
+
+    config.set("some.*.attribute", "value")
+    config.get("some.id.attribute")  # => "value"
+    config.get("some.other.attribute")  # => "value"
+    config.get("some.other.deeper.attribute")  # => "value"
+"""
+
+import re
+
+
+class Config:
+    def __init__(self):
+        self.__backend = {}
+        self.__cache = {}
+
+    def get(self, path, default=None):
+        # find all patterns that match the path
+        matches = [
+            pattern
+            for pattern in self.__backend
+            if self.__match(
+                pattern,
+                path,
+            )
+        ]
+
+        if not matches and default is not None:
+            return default
+
+        if not matches:
+            raise KeyError(f"No config defined for '{path}'")
+
+        # sort patterns - highest priority first
+        matches = sorted(
+            matches,
+            key=self.__priority,
+            reverse=True,
+        )
+
+        return self.__backend[matches[0]]
+
+    def __match(self, pattern, path):
+        if (pattern, path) not in self.__cache:
+            regex = pattern
+
+            # match actual period characters
+            regex = regex.replace(".", r"\.")
+            # a "*" can match multiple parts
+            regex = regex.replace("*", r"\w+(.\w+)*")
+            # pattern matches the entire path
+            matcher = re.compile(f"^{regex}$")
+
+            match = matcher.match(path)
+            self.__cache[(pattern, path)] = match
+
+        return self.__cache[(pattern, path)]
+
+    def __priority(self, pattern):
+        parts = pattern.split(".")
+
+        # first sort by pattern length
+        score = len(parts)
+
+        # then score by specificity
+        ids = [part for part in parts if part != "*"]
+        score += len(ids) * 0.1
+
+        return score
+
+    def set(self, path, value):
+        self.__backend[path] = value
+
+    def reset(self):
+        self.__backend = {}

--- a/src/snsary/utils/tracing/core.py
+++ b/src/snsary/utils/tracing/core.py
@@ -1,0 +1,47 @@
+import functools
+
+from ..logging import get_logger
+from .config import Config
+from .registry import Registry
+from .sample import Sample
+
+_config = Config()
+_registry = Registry(_config)
+
+
+def reset():
+    _config.reset()
+    _registry.reset()
+
+
+def configure(settings):
+    for path, value in settings.items():
+        _config.set(path, value)
+
+
+def capture_exceptions(trace_id):
+    def _factory(fn):
+        @functools.wraps(fn)
+        def _wrapper(*args, **kwargs):
+            enabled = _config.get(f"{trace_id}.enabled", default=False)
+            monitors = _registry.get(trace_id)
+
+            if not enabled:
+                return fn(*args, **kwargs)
+
+            try:
+                result = fn(*args, **kwargs)
+
+                for monitor in monitors:
+                    monitor.analyse(Sample.SUCCESS)
+
+                return result
+            except Exception as e:
+                for monitor in monitors:
+                    monitor.analyse(Sample.FAILURE)
+
+                get_logger().warning(e)
+
+        return _wrapper
+
+    return _factory

--- a/src/snsary/utils/tracing/history.py
+++ b/src/snsary/utils/tracing/history.py
@@ -1,0 +1,28 @@
+"""
+Represents a FIFO list of :mod:`Samples <snsary.utils.tracing.sample>`. :mod:`Samples <snsary.utils.tracing.sample>` are added to the list with ``add``. The oldest :mod:`Sample <snsary.utils.tracing.sample>` is ejected when the list reaches the specified ``max_length``.
+"""
+
+
+class History:
+    def __init__(self, *, max_length):
+        self.__max_length = max_length
+        self.__backend = []
+
+    @property
+    def max_length(self):
+        return self.__max_length
+
+    def add(self, sample):
+        self.__backend.append(sample)
+
+        if len(self) > self.max_length:
+            self.__backend.pop(0)
+
+    def reset(self):
+        self.__backend.clear()
+
+    def __len__(self):
+        return len(self.__backend)
+
+    def __iter__(self):
+        return iter(self.__backend)

--- a/src/snsary/utils/tracing/monitors.py
+++ b/src/snsary/utils/tracing/monitors.py
@@ -1,0 +1,92 @@
+from ..logging import get_logger
+from .history import History
+from .sample import Sample
+
+
+class Monitor:
+    """
+    Analyses :mod:`Samples <snsary.utils.tracing.sample>` of the execution of some code.
+    """
+
+    def analyse(self, sample):
+        raise NotImplementedError()
+
+    @classmethod
+    def factory(cls, **kwargs):
+        return lambda: cls(**kwargs)
+
+
+class TimeSeriesAlert(Monitor):
+    """
+    Provides a :mod:`History <snsary.utils.tracing.history>` of :mod:`Samples <snsary.utils.tracing.sample>` over time to support time series alerting. Each subclass is responsible for managing the history.
+    """
+
+    MAX_HISTORY = 60
+
+    def __init__(self, *, history=None):
+        self._history = (
+            history
+            if history is not None
+            else History(
+                max_length=self.MAX_HISTORY,
+            )
+        )
+
+
+class LivenessAlert(TimeSeriesAlert):
+    """
+    Logs an error when a complete history of samples is nothing but failures.
+
+    The history is reset every time the monitor logs an error.
+    """
+
+    def analyse(self, sample):
+        self._history.add(sample)
+
+        if len(self._history) < self._history.max_length:
+            return
+
+        for sample in self._history:
+            if sample == Sample.SUCCESS:
+                return
+
+        get_logger().error(
+            f"Alert: {self._history.max_length} failures in sample window"
+        )
+        self._history.reset()
+
+
+class GapAlert(TimeSeriesAlert):
+    """
+    Logs an error when there are too many gaps in ``SUCCESS`` samples. A gap
+    is one or more ``FAILURE`` samples followed by a ``SUCCESS`` sample.
+
+    The history is reset every time the monitor logs an error.
+    """
+
+    MAX_GAPS = 5
+
+    def __init__(self, *, max_gaps=MAX_GAPS, **kwargs):
+        TimeSeriesAlert.__init__(self, **kwargs)
+        self.__max_gaps = max_gaps
+
+    def analyse(self, sample):
+        self._history.add(sample)
+
+        if self.__count_gaps() <= self.__max_gaps:
+            return
+
+        get_logger().error(f"Alert: {self.__max_gaps + 1} gaps in last sample window")
+        self._history.reset()
+
+    def __count_gaps(self):
+        gaps = 0
+        previous = None
+
+        for sample in self._history:
+            if previous == Sample.FAILURE and sample == Sample.SUCCESS:
+                gaps += 1
+
+            previous = sample
+
+        return gaps

--- a/src/snsary/utils/tracing/registry.py
+++ b/src/snsary/utils/tracing/registry.py
@@ -1,0 +1,54 @@
+"""
+Manages the :mod:`Monitors <snsary.utils.tracing.monitors>` associated with an instrumented block of code. Calling ``get`` will return a list of instances of any :mod:`Monitors <snsary.utils.tracing.monitors>` set in :mod:`Config <snsary.utils.tracing.config>` for the specified ``trace_id``: ::
+
+    config = Config()
+    config.set("some.id.monitors", [Monitor.factory()])
+
+    registry = Registry(config)
+    registry.get("some.id")  # => [<Monitor>]
+
+The same instances are returned across calls to ``get`` for the same ``trace_id``. Setting ``thread_aware`` in :mod:`Config <snsary.utils.tracing.config>` means the returned instances will also be unique across threads.
+"""
+
+from threading import current_thread
+
+
+class Registry:
+    def __init__(self, config):
+        self.__backend = {}
+        self.__config = config
+
+    def reset(self):
+        self.__backend = {}
+
+    def get(self, trace_id):
+        registry_id = self.__registry_id(trace_id)
+
+        if registry_id not in self.__backend:
+            monitors = self.__monitors(trace_id)
+            self.__backend[registry_id] = monitors
+
+        return self.__backend[registry_id]
+
+    def __monitors(self, trace_id):
+        return [
+            monitor_class()
+            for monitor_class in self.__config.get(
+                f"{trace_id}.monitors",
+                default=[],
+            )
+        ]
+
+    def __registry_id(self, trace_id):
+        registry_id = f"[trace_id={trace_id}]"
+
+        thread_aware = self.__config.get(
+            f"{trace_id}.thread_aware",
+            default=False,
+        )
+
+        if thread_aware:
+            thread_ident = current_thread().ident
+            registry_id += f"[thread_ident={thread_ident}]"
+
+        return registry_id

--- a/src/snsary/utils/tracing/sample.py
+++ b/src/snsary/utils/tracing/sample.py
@@ -1,0 +1,3 @@
+class Sample:
+    SUCCESS = "success"
+    FAILURE = "failure"

--- a/tests/utils/tracing/test_config.py
+++ b/tests/utils/tracing/test_config.py
@@ -1,0 +1,56 @@
+import pytest
+
+from snsary.utils.tracing.config import Config
+
+
+def test_get_set():
+    config = Config()
+
+    # "*" matches at any level
+    config.set("*.attr", 1)
+    assert config.get("p1.attr") == 1
+    assert config.get("p1.p2.attr") == 1
+    assert config.get("p1.p2.p3.attr") == 1
+
+    # prioritise specific patterns
+    config.set("p1.attr", 2)
+    assert config.get("p1.attr") == 2
+    assert config.get("p1.p2.attr") == 1
+    assert config.get("p1.p2.p3.attr") == 1
+
+    # prioritise longer patterns
+    config.set("p1.*.attr", 3)
+    assert config.get("p1.attr") == 2
+    assert config.get("p1.p2.attr") == 3
+    assert config.get("p1.p2.p3.attr") == 3
+
+    # ignore less specific pattern
+    config.set("*.*.attr", 4)
+    assert config.get("p1.p2.attr") == 3
+    assert config.get("p1.p2.p3.attr") == 3
+
+    # prioritise more specific pattern
+    config.set("p1.p2.attr", 4)
+    assert config.get("p1.p2.attr") == 4
+    assert config.get("p1.p2.p3.attr") == 3
+
+    # prioritise even longer pattern
+    config.set("*.*.*.attr", 5)
+    assert config.get("p1.p2.p3.attr") == 5
+
+    # return default if no match found
+    assert config.get("unknown", default=[]) == []
+
+    # raise error if no default provided
+    with pytest.raises(KeyError):
+        config.get("something.else")
+
+
+def test_reset():
+    config = Config()
+    config.set("a", "c")
+    assert config.get("a") == "c"
+
+    config.reset()
+    with pytest.raises(KeyError):
+        config.get("a")

--- a/tests/utils/tracing/test_config.py
+++ b/tests/utils/tracing/test_config.py
@@ -6,51 +6,29 @@ from snsary.utils.tracing.config import Config
 def test_get_set():
     config = Config()
 
-    # "*" matches at any level
-    config.set("*.attr", 1)
-    assert config.get("p1.attr") == 1
-    assert config.get("p1.p2.attr") == 1
-    assert config.get("p1.p2.p3.attr") == 1
+    # exact match
+    config.set("prefix.attr", 1)
+    assert config.get("prefix.attr") == 1
 
-    # prioritise specific patterns
-    config.set("p1.attr", 2)
-    assert config.get("p1.attr") == 2
-    assert config.get("p1.p2.attr") == 1
-    assert config.get("p1.p2.p3.attr") == 1
-
-    # prioritise longer patterns
-    config.set("p1.*.attr", 3)
-    assert config.get("p1.attr") == 2
-    assert config.get("p1.p2.attr") == 3
-    assert config.get("p1.p2.p3.attr") == 3
-
-    # ignore less specific pattern
-    config.set("*.*.attr", 4)
-    assert config.get("p1.p2.attr") == 3
-    assert config.get("p1.p2.p3.attr") == 3
-
-    # prioritise more specific pattern
-    config.set("p1.p2.attr", 4)
-    assert config.get("p1.p2.attr") == 4
-    assert config.get("p1.p2.p3.attr") == 3
-
-    # prioritise even longer pattern
-    config.set("*.*.*.attr", 5)
-    assert config.get("p1.p2.p3.attr") == 5
-
-    # return default if no match found
-    assert config.get("unknown", default=[]) == []
-
-    # raise error if no default provided
+    # no match
     with pytest.raises(KeyError):
-        config.get("something.else")
+        config.get("prefix.more.attr")
+
+    # default match
+    assert config.get("prefix.more.attr", default=1) == 1
+    assert config.get("prefix.attr", default=2) == 1
+
+    # top-level match
+    config.set("attr", 2)
+    assert config.get("prefix.more.attr") == 2
+    assert config.get("prefix.attr") == 1
 
 
 def test_reset():
     config = Config()
-    config.set("a", "c")
-    assert config.get("a") == "c"
+    config.set("attr", 1)
+    assert config.get("prefix.attr") == 1
 
     config.reset()
     with pytest.raises(KeyError):
-        config.get("a")
+        config.get("prefix.attr")

--- a/tests/utils/tracing/test_core.py
+++ b/tests/utils/tracing/test_core.py
@@ -1,0 +1,93 @@
+import pytest
+
+from snsary.utils.tracing import Monitor, Sample, capture_exceptions, configure, reset
+
+
+@pytest.fixture
+def fake_monitor():
+    class FakeMonitor(Monitor):
+        samples = []
+
+        def analyse(self, sample):
+            FakeMonitor.samples += [sample]
+
+    return FakeMonitor
+
+
+@pytest.fixture(autouse=True)
+def tracing_session():
+    yield
+    reset()
+
+
+@capture_exceptions("failure")
+def wrapped_failure():
+    raise Exception("uh oh")
+
+
+@capture_exceptions("success")
+def wrapped_success():
+    return "pass"
+
+
+def test_capture_exceptions(
+    fake_monitor,
+    caplog,
+):
+    configure(
+        {
+            "*.enabled": True,
+            "*.monitors": [fake_monitor.factory()],
+        }
+    )
+
+    assert not wrapped_failure()
+    assert wrapped_success() == "pass"
+
+    assert fake_monitor.samples == [Sample.FAILURE, Sample.SUCCESS]
+    assert "uh oh" in caplog.text
+
+
+def test_capture_exceptions_without_tracing(
+    fake_monitor,
+):
+    with pytest.raises(Exception):
+        wrapped_failure()
+
+    assert wrapped_success() == "pass"
+    assert len(fake_monitor.samples) == 0
+
+
+def test_capture_exceptions_partial_tracing(
+    fake_monitor,
+):
+    configure(
+        {
+            "success.monitors": [fake_monitor.factory()],
+            "success.enabled": True,
+        },
+    )
+    assert wrapped_success() == "pass"
+    assert len(fake_monitor.samples) == 1
+
+    configure({"success.enabled": False})
+    assert wrapped_success() == "pass"
+    assert len(fake_monitor.samples) == 1
+
+
+def test_capture_exceptions_persists_monitors(
+    fake_monitor,
+):
+    configure(
+        {
+            "success.monitors": [fake_monitor.factory()],
+            "success.enabled": True,
+        }
+    )
+
+    wrapped_success()
+    assert len(fake_monitor.samples) == 1
+
+    configure({"success.monitors": ["not a monitor"]})
+    wrapped_success()
+    assert len(fake_monitor.samples) == 2

--- a/tests/utils/tracing/test_core.py
+++ b/tests/utils/tracing/test_core.py
@@ -36,8 +36,8 @@ def test_capture_exceptions(
 ):
     configure(
         {
-            "*.enabled": True,
-            "*.monitors": [fake_monitor.factory()],
+            "enabled": True,
+            "monitors": [fake_monitor.factory()],
         }
     )
 

--- a/tests/utils/tracing/test_monitors.py
+++ b/tests/utils/tracing/test_monitors.py
@@ -1,0 +1,51 @@
+from snsary.utils.tracing import GapAlert, History, LivenessAlert, Sample
+
+
+class TestGapAlert:
+    def test_analyse(self, caplog):
+        monitor = GapAlert(max_gaps=1)
+        expected_log = "Alert: 2 gaps in last sample window"
+
+        # first gap
+        monitor.analyse(Sample.FAILURE)
+        monitor.analyse(Sample.FAILURE)
+        monitor.analyse(Sample.SUCCESS)
+        assert expected_log not in caplog.text
+
+        # second gap
+        monitor.analyse(Sample.FAILURE)
+        monitor.analyse(Sample.SUCCESS)
+        assert expected_log in caplog.text
+        caplog.clear()
+
+        # first gap (after reset)
+        monitor.analyse(Sample.FAILURE)
+        monitor.analyse(Sample.SUCCESS)
+        assert expected_log not in caplog.text
+
+        # not a gap
+        monitor.analyse(Sample.FAILURE)
+        assert expected_log not in caplog.text
+
+
+class TestLivenessAlert:
+    def test_analyse(self, caplog):
+        monitor = LivenessAlert(history=History(max_length=2))
+        expected_log = "Alert: 2 failures in sample window"
+
+        # first fail
+        monitor.analyse(Sample.FAILURE)
+        assert expected_log not in caplog.text
+
+        # second fail
+        monitor.analyse(Sample.FAILURE)
+        assert expected_log in caplog.text
+        caplog.clear()
+
+        # first fail (after reset)
+        monitor.analyse(Sample.FAILURE)
+        assert expected_log not in caplog.text
+
+        # not a fail
+        monitor.analyse(Sample.SUCCESS)
+        assert expected_log not in caplog.text

--- a/tests/utils/tracing/test_registry.py
+++ b/tests/utils/tracing/test_registry.py
@@ -1,0 +1,68 @@
+from threading import Thread
+
+import pytest
+
+from snsary.utils.tracing import Config, Monitor, Registry
+
+
+@pytest.fixture
+def config():
+    return Config()
+
+
+class FakeMonitor(Monitor):
+    pass
+
+
+def test_get(config):
+    config.set("some.id.monitors", [FakeMonitor.factory()])
+    registry = Registry(config)
+    monitors = registry.get("some.id")
+
+    assert len(monitors) == 1
+    assert isinstance(monitors[0], FakeMonitor)
+
+    assert registry.get("some.id") == monitors
+    assert registry.get("other.id") != monitors
+
+
+def test_get_no_config():
+    registry = Registry(Config())
+    assert len(registry.get("some.id")) == 0
+
+
+def test_get_thread_aware(config):
+    config.set("*.thread_aware", True)
+    config.set("*.monitors", [FakeMonitor.factory()])
+    registry = Registry(config)
+    monitors = registry.get("some.id")
+    other_monitors = None
+
+    def target():
+        nonlocal other_monitors
+        other_monitors = registry.get("some.id")
+
+    thread = Thread(target=target)
+    thread.start()
+    thread.join()
+
+    assert monitors != other_monitors
+    assert len(other_monitors) == 1
+    assert isinstance(other_monitors[0], FakeMonitor)
+
+
+def test_get_not_thread_aware(config):
+    config.set("*.monitors", [FakeMonitor.factory()])
+    registry = Registry(config)
+    monitors = registry.get("some.id")
+    other_monitors = None
+
+    def target():
+        nonlocal other_monitors
+        other_monitors = registry.get("some.id")
+
+    thread = Thread(target=target)
+    thread.start()
+    thread.join()
+
+    assert monitors == other_monitors

--- a/tests/utils/tracing/test_registry.py
+++ b/tests/utils/tracing/test_registry.py
@@ -32,8 +32,8 @@ def test_get_no_config():
 
 
 def test_get_thread_aware(config):
-    config.set("*.thread_aware", True)
-    config.set("*.monitors", [FakeMonitor.factory()])
+    config.set("thread_aware", True)
+    config.set("monitors", [FakeMonitor.factory()])
     registry = Registry(config)
     monitors = registry.get("some.id")
     other_monitors = None
@@ -52,7 +52,7 @@ def test_get_thread_aware(config):
 
 
 def test_get_not_thread_aware(config):
-    config.set("*.monitors", [FakeMonitor.factory()])
+    config.set("monitors", [FakeMonitor.factory()])
     registry = Registry(config)
     monitors = registry.get("some.id")
     other_monitors = None


### PR DESCRIPTION
This should retain visibility of issues that need attention, but avoid the
 following kinds of occasional error:

    [snsary.pmsx003] message header: b''
    [snsary.graphiteoutput] ('Connection aborted.', OSError(107, 'Transport endpoint is not connected'))
    [snsary.pmsx003] message checksum 33534 != 663
    [snsary.scd30] [Errno 121] Remote I/O error