### PR TITLE
Enable request retries for GraphiteOutput

### DIFF
--- a/src/snsary/contrib/awair.py
+++ b/src/snsary/contrib/awair.py
@@ -10,11 +10,10 @@ import os
 from datetime import timedelta
 
 import pyrfc3339
-import requests
 
 from snsary.models import Reading
 from snsary.sources import PollingSensor
-from snsary.utils import logging
+from snsary.utils import logging, request
 
 
 class AwairSensor(PollingSensor):
@@ -32,7 +31,7 @@ class AwairSensor(PollingSensor):
     def discover(cls, *, token):
         logger = logging.get_logger()
         logger.debug(f"Request {cls.DEVICES_URL}")
-        response = requests.get(
+        response = request.retrying_session().get(
             cls.DEVICES_URL,
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -74,7 +73,7 @@ class AwairSensor(PollingSensor):
         )
 
         self.logger.debug(f"Request {url}")
-        response = requests.get(
+        response = request.retrying_session().get(
             url,
             headers={"Authorization": f"Bearer {self.__token}"},
         )

--- a/src/snsary/contrib/grafana.py
+++ b/src/snsary/contrib/grafana.py
@@ -8,9 +8,8 @@ import json
 import os
 import platform
 
-import requests
-
 from snsary.outputs import BatchOutput
+from snsary.utils import request
 
 
 class GraphiteOutput(BatchOutput):
@@ -30,7 +29,7 @@ class GraphiteOutput(BatchOutput):
         data = self.__format(readings)
         self.logger.debug(f"Sending {data}")
 
-        response = requests.post(
+        response = request.retrying_session().post(
             self.__url,
             data=data,
             headers={"Content-Type": "application/json"},

--- a/src/snsary/contrib/octopus.py
+++ b/src/snsary/contrib/octopus.py
@@ -10,10 +10,10 @@ import os
 from datetime import timedelta
 
 import pyrfc3339
-import requests
 
 from snsary.models import Reading
 from snsary.sources import PollingSensor
+from snsary.utils import request
 
 
 class OctopusSensor(PollingSensor):
@@ -52,8 +52,12 @@ class OctopusSensor(PollingSensor):
         )
 
         self.logger.debug(f"Request {url}")
-        response = requests.get(url, auth=(self.__token, ""))
+        response = request.retrying_session().get(
+            url,
+            auth=(self.__token, ""),
+        )
         response.raise_for_status()
+
         samples = response.json()["results"]
         self.logger.debug(f"Response {samples}")
 

--- a/src/snsary/utils/request.py
+++ b/src/snsary/utils/request.py
@@ -1,0 +1,16 @@
+import requests
+from urllib3 import util
+
+
+def retrying_session():
+    adapter = requests.adapters.HTTPAdapter(
+        max_retries=util.Retry(
+            total=3,
+            allowed_methods=False,
+        )
+    )
+
+    session = requests.Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session

--- a/tests/utils/test_request.py
+++ b/tests/utils/test_request.py
@@ -1,0 +1,7 @@
+from snsary.utils import request
+
+
+def test_retrying_session():
+    session = request.retrying_session()
+    assert session.get_adapter("http://something").max_retries.total == 3
+    assert session.get_adapter("https://something").max_retries.total == 3


### PR DESCRIPTION
This output logs many more errors compared to the others. Doing a
few retries should help reduce this unnecessary noise with minimal
effort, noting that it's not a big issue if some data is dropped
ocassionally since the subsequent values will usually be similar.