### PR TITLE
Fix GitHub Actions failing due to legacy grpcio

### DIFF
--- a/requirements/google/extra.txt
+++ b/requirements/google/extra.txt
@@ -1,3 +1,1 @@
-grpcio<1.45.0
-grpcio-status<1.45.0
 google-cloud-bigquery-storage


### PR DESCRIPTION
Testing the latest version (1.51.1) shows this works for GitHub CI
and (crucially) on the Raspberry Pi i.e. it's not safe to upgrade.