### PR TITLE
Fix missing pimoroni dependency in Python 3.10

### DIFF
--- a/requirements/pimoroni/tests.txt
+++ b/requirements/pimoroni/tests.txt
@@ -1,1 +1,2 @@
 pimoroni-mics6814>=0.0.2
+smbus2>=0.4.2


### PR DESCRIPTION
This will be fixed in a newer version of the library [^1], but for
now this gets the tests passing again.

[^1]: https://github.com/pimoroni/ioe-python/pull/22